### PR TITLE
Added include dir to installation of rcl_logging_log4cxx.

### DIFF
--- a/rcl_logging_log4cxx/CMakeLists.txt
+++ b/rcl_logging_log4cxx/CMakeLists.txt
@@ -50,6 +50,10 @@ install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION include/${PROJECT_NAME}
+)
+
 ament_export_include_directories(include)
 ament_export_dependencies(ament_cmake)
 ament_export_libraries(${PROJECT_NAME} log4cxx)


### PR DESCRIPTION
Fixes issue [#5](https://github.com/ros2/rcl_logging/issues/5). This enables compiling ROS2 with log4cxx (by setting RCL_LOGGING_IMPLEMENTATION to rcl_logging_log4cxx).