### PR TITLE
Adds include directory to install to fix compilation error with rcl building with rcl_logging_log4cxx.

### DIFF
--- a/rcl_logging_log4cxx/CMakeLists.txt
+++ b/rcl_logging_log4cxx/CMakeLists.txt
@@ -54,3 +54,8 @@ ament_export_include_directories(include)
 ament_export_dependencies(ament_cmake)
 ament_export_libraries(${PROJECT_NAME} log4cxx)
 ament_package()
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)


### PR DESCRIPTION
When setting rcl_logging_log4cxx as the default logger you get a build error because rcl cannot find the include directory that rcl_logging_log4cxx says should be there. This fixes that issue. 