### PR TITLE
Changing the default location for log files to be a local directory instead of /var/log/ros on linux due to permission issues.

### DIFF
--- a/rcl_logging_log4cxx/CMakeLists.txt
+++ b/rcl_logging_log4cxx/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories(${ament_INCLUDE_DIRS} include)
 if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 else()
-  # Disable ddl-interface warnings for STL from log4cxx code, because we are already 
+  # Disable ddl-interface warnings for STL from log4cxx code, because we are already
   # forced to use the same compiler in Windows, as we are getting the binaries
   # for log4cxx from Chocolatey
   # https://web.archive.org/web/20130317015847/http://connect.microsoft.com/VisualStudio/feedback/details/696593/vc-10-vs-2010-basic-string-exports
@@ -32,7 +32,6 @@ endif()
 set(${PROJECT_NAME}_sources
     src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
 )
-#set_source_files_properties(${${PROJECT_NAME}_sources} PROPERTIES language "CXX")
 
 if(NOT WIN32)
   add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})

--- a/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
+++ b/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
@@ -147,12 +147,9 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
       // logging.
       return RC_LOGGING_RET_ERROR;
     }
-    // We only want the basename of the program name (in case the OS returns a
-    // a full path).
-    char *basename = ::basename(basec);
 
     char log_name_buffer[512] = {0};
-    snprintf(log_name_buffer, sizeof(log_name_buffer), "%s/.ros/log/%s_%i_%" PRId64 ".log", homedir, basename, rcutils_get_pid(), ms_since_epoch);
+    snprintf(log_name_buffer, sizeof(log_name_buffer), "%s/.ros/log/%s_%i_%" PRId64 ".log", homedir, basec, rcutils_get_pid(), ms_since_epoch);
     allocator.deallocate(basec, allocator.state);
     fprintf(stderr, "CHRIS: log_name_buffer: %s\n", log_name_buffer);
     std::string log_name_str(log_name_buffer);

--- a/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
+++ b/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
@@ -26,7 +26,7 @@
 
 #include <rcutils/allocator.h>
 #include <rcutils/get_env.h>
-#include <rcutils/program.h>
+#include <rcutils/process.h>
 #include <rcutils/time.h>
 
 /**
@@ -141,7 +141,7 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
     int64_t ms_since_epoch = RCUTILS_NS_TO_MS(now);
 
     // Get the program name.
-    char *basec = rcutils_get_program_name(allocator);
+    char *basec = rcutils_get_executable_name(allocator);
     if (basec == NULL) {
       // We couldn't get the program name, so get out of here without setting up
       // logging.

--- a/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
+++ b/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
@@ -72,15 +72,13 @@ extern "C" {
 
 #include "rcl_logging_log4cxx/logging_interface.h"
 
+#define DEFAULT_LOG_FILE    "ros_logs/%i.log"
 #if defined _WIN32 || defined __CYGWIN__
     #include <Windows.h>
     #define GET_PID() ((int)GetCurrentProcessId())
-/* TODO(nburek): Change this to default to the %appdata% folder on Windows */
-    #define DEFAULT_LOG_FILE    "ros_logs/%i.log"
 #else
     #include <unistd.h>
     #define GET_PID() ((int)getpid())
-    #define DEFAULT_LOG_FILE    "/var/log/ros/%i.log"
 #endif
 
 

--- a/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
+++ b/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
@@ -151,7 +151,6 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
     char log_name_buffer[512] = {0};
     snprintf(log_name_buffer, sizeof(log_name_buffer), "%s/.ros/log/%s_%i_%" PRId64 ".log", homedir, basec, rcutils_get_pid(), ms_since_epoch);
     allocator.deallocate(basec, allocator.state);
-    fprintf(stderr, "CHRIS: log_name_buffer: %s\n", log_name_buffer);
     std::string log_name_str(log_name_buffer);
     LOG4CXX_DECODE_CHAR(log_name_l4cxx_str, log_name_str);
     log4cxx::FileAppenderPtr file_appender(new log4cxx::FileAppender(layout, log_name_l4cxx_str,

--- a/rcl_logging_noop/CMakeLists.txt
+++ b/rcl_logging_noop/CMakeLists.txt
@@ -21,9 +21,8 @@ if(NOT WIN32)
 endif()
 
 set(${PROJECT_NAME}_sources
-    src/rcl_logging_noop/rcl_logging_noop.cpp
+  src/rcl_logging_noop/rcl_logging_noop.cpp
 )
-#set_source_files_properties(${${PROJECT_NAME}_sources} PROPERTIES language "CXX")
 
 if(NOT WIN32)
   add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})


### PR DESCRIPTION
During the review of this PR: https://github.com/ros2/rcl/pull/425 we found that there were permission issues with writing to /var/log. The quick fix for this is to use the same behavior that we have on Windows, which is to log to a local directory instead. 