### PR TITLE
Implement a backend logger using spdlog.

### DIFF
--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rcl_logging_spdlog)
+
+# Default to C11
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 11)
+endif()
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+find_package(ament_cmake_ros REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(spdlog_vendor REQUIRED) # Provides spdlog 1.3.1 on platforms without it.
+find_package(spdlog REQUIRED)
+
+include_directories(include)
+
+if(NOT WIN32)
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+add_library(${PROJECT_NAME} src/rcl_logging_spdlog.cpp)
+target_link_libraries(${PROJECT_NAME} spdlog::spdlog)
+
+ament_target_dependencies(${PROJECT_NAME}
+  rcutils
+  spdlog
+)
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_LOGGING_BUILDING_DLL")
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+ament_export_include_directories(include)
+ament_export_dependencies(ament_cmake rcutils spdlog)
+ament_export_libraries(${PROJECT_NAME})
+ament_package()

--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -41,6 +41,11 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION include/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_export_include_directories(include)
 ament_export_dependencies(ament_cmake rcutils spdlog)
 ament_export_libraries(${PROJECT_NAME})

--- a/rcl_logging_spdlog/include/rcl_logging_spdlog/logging_interface.h
+++ b/rcl_logging_spdlog/include/rcl_logging_spdlog/logging_interface.h
@@ -24,7 +24,9 @@ extern "C" {
 typedef int rcl_logging_ret_t;
 
 RCL_LOGGING_PUBLIC
-rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcutils_allocator_t allocator);
+rcl_logging_ret_t rcl_logging_external_initialize(
+  const char * config_file,
+  rcutils_allocator_t allocator);
 
 RCL_LOGGING_PUBLIC
 rcl_logging_ret_t rcl_logging_external_shutdown();

--- a/rcl_logging_spdlog/include/rcl_logging_spdlog/logging_interface.h
+++ b/rcl_logging_spdlog/include/rcl_logging_spdlog/logging_interface.h
@@ -1,0 +1,43 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL_LOGGING_SPDLOG__LOGGING_INTERFACE_H_
+#define RCL_LOGGING_SPDLOG__LOGGING_INTERFACE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "rcl_logging_spdlog/visibility_control.h"
+
+typedef int rcl_logging_ret_t;
+
+RCL_LOGGING_PUBLIC
+rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcutils_allocator_t allocator);
+
+RCL_LOGGING_PUBLIC
+rcl_logging_ret_t rcl_logging_external_shutdown();
+
+RCL_LOGGING_PUBLIC
+void rcl_logging_external_log(int severity, const char * name, const char * msg);
+
+RCL_LOGGING_PUBLIC
+rcl_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level);
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif  // RCL_LOGGING_SPDLOG__LOGGING_INTERFACE_H_

--- a/rcl_logging_spdlog/include/rcl_logging_spdlog/visibility_control.h
+++ b/rcl_logging_spdlog/include/rcl_logging_spdlog/visibility_control.h
@@ -1,0 +1,54 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL_LOGGING_SPDLOG__VISIBILITY_CONTROL_H_
+#define RCL_LOGGING_SPDLOG__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define RCL_LOGGING_EXPORT __attribute__ ((dllexport))
+    #define RCL_LOGGING_IMPORT __attribute__ ((dllimport))
+  #else
+    #define RCL_LOGGING_EXPORT __declspec(dllexport)
+    #define RCL_LOGGING_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef RCL_LOGGING_BUILDING_DLL
+    #define RCL_LOGGING_PUBLIC RCL_LOGGING_EXPORT
+  #else
+    #define RCL_LOGGING_PUBLIC RCL_LOGGING_IMPORT
+  #endif
+  #define RCL_LOGGING_PUBLIC_TYPE RCL_LOGGING_PUBLIC
+  #define RCL_LOGGING_LOCAL
+#else
+  #define RCL_LOGGING_EXPORT __attribute__ ((visibility("default")))
+  #define RCL_LOGGING_IMPORT
+  #if __GNUC__ >= 4
+    #define RCL_LOGGING_PUBLIC __attribute__ ((visibility("default")))
+    #define RCL_LOGGING_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define RCL_LOGGING_PUBLIC
+    #define RCL_LOGGING_LOCAL
+  #endif
+  #define RCL_LOGGING_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif  // RCL_LOGGING_SPDLOG__VISIBILITY_CONTROL_H_

--- a/rcl_logging_spdlog/package.xml
+++ b/rcl_logging_spdlog/package.xml
@@ -6,7 +6,7 @@
   <description>C API providing common interface to a shared library wrapping 3rd party loggers.</description>
   <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
   <author email="clalancette@openrobotics.org">Chris Lalancette</author>
-  <license>MIT</license>
+  <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 

--- a/rcl_logging_spdlog/package.xml
+++ b/rcl_logging_spdlog/package.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rcl_logging_spdlog</name>
-  <version>0.1.0</version>
-  <description>C API providing common interface to a shared library wrapping 3rd party loggers.</description>
+  <version>0.3.0</version>
+  <description>Implementation of rcl_logging API for an spdlog backend.</description>
   <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
-  <author email="clalancette@openrobotics.org">Chris Lalancette</author>
   <license>Apache License 2.0</license>
+  <author email="clalancette@openrobotics.org">Chris Lalancette</author>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
@@ -14,6 +14,9 @@
   <build_depend>spdlog</build_depend>
 
   <depend>rcutils</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <member_of_group>rcl_logging_packages</member_of_group>
 

--- a/rcl_logging_spdlog/package.xml
+++ b/rcl_logging_spdlog/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rcl_logging_spdlog</name>
+  <version>0.1.0</version>
+  <description>C API providing common interface to a shared library wrapping 3rd party loggers.</description>
+  <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
+  <author email="clalancette@openrobotics.org">Chris Lalancette</author>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <build_depend>spdlog_vendor</build_depend>
+  <build_depend>spdlog</build_depend>
+
+  <depend>rcutils</depend>
+
+  <member_of_group>rcl_logging_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -1,0 +1,155 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cerrno>
+#include <inttypes.h>
+
+#include <rcutils/allocator.h>
+#include <rcutils/filesystem.h>
+#include <rcutils/get_env.h>
+#include <rcutils/process.h>
+#include <rcutils/time.h>
+
+#include "spdlog/spdlog.h"
+#include "spdlog/sinks/basic_file_sink.h"
+
+#include "rcl_logging_spdlog/logging_interface.h"
+
+#define RC_LOGGING_RET_OK                          (0)
+#define RC_LOGGING_RET_ERROR                       (2)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static std::shared_ptr<spdlog::logger> g_root_logger;
+
+/* These are defined here to match the severity levels in rcl. They provide a consistent way for external logger
+    implementations to map between the incoming integer severity from ROS to the concept of DEBUG, INFO, WARN, ERROR,
+    and FATAL*/
+enum RC_LOGGING_LOG_SEVERITY
+{
+  RC_LOGGING_SEVERITY_UNSET = 0,  ///< The unset log level
+  RC_LOGGING_SEVERITY_DEBUG = 10,  ///< The debug log level
+  RC_LOGGING_SEVERITY_INFO = 20,  ///< The info log level
+  RC_LOGGING_SEVERITY_WARN = 30,  ///< The warn log level
+  RC_LOGGING_SEVERITY_ERROR = 40,  ///< The error log level
+  RC_LOGGING_SEVERITY_FATAL = 50,  ///< The fatal log level
+};
+
+static spdlog::level::level_enum map_external_log_level_to_library_level(int external_level)
+{
+  spdlog::level::level_enum level;
+
+  // map to the next highest level of severity
+  if (external_level <= RC_LOGGING_SEVERITY_DEBUG) {
+    level = spdlog::level::level_enum::debug;
+  } else if (external_level <= RC_LOGGING_SEVERITY_INFO) {
+    level = spdlog::level::level_enum::info;
+  } else if (external_level <= RC_LOGGING_SEVERITY_WARN) {
+    level = spdlog::level::level_enum::warn;
+  } else if (external_level <= RC_LOGGING_SEVERITY_ERROR) {
+    level = spdlog::level::level_enum::err;
+  } else if (external_level <= RC_LOGGING_SEVERITY_FATAL) {
+    level = spdlog::level::level_enum::critical;
+  }
+  return level;
+}
+
+rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcutils_allocator_t allocator)
+{
+  bool config_file_provided = (nullptr != config_file) && (config_file[0] != '\0');
+  if (config_file_provided) {
+    // TODO(clalancette): implement support for an external configuration file.
+    return RC_LOGGING_RET_ERROR;
+  } else {
+    // To be compatible with ROS 1, we want to construct a default filename of
+    // the form ~/.ros/log/<exe>_<pid>_<milliseconds-since-epoch>.log
+
+    // First get the home directory.
+    const char *homedir = rcutils_get_home_dir();
+    if (homedir == NULL) {
+      // We couldn't get the home directory; it is not really going to be
+      // possible to do logging properly, so get out of here without setting
+      // up logging.
+      return RC_LOGGING_RET_ERROR;
+    }
+
+    // SPDLOG doesn't automatically create the log directories, so make them
+    // by hand here.
+    char dotrosdir[512] = {0};
+    snprintf(dotrosdir, sizeof(dotrosdir), "%s/.ros", homedir);
+    if (!rcutils_mkdir(dotrosdir)) {
+      return RC_LOGGING_RET_ERROR;
+    }
+
+    char logdir[512] = {0};
+    snprintf(logdir, sizeof(logdir), "%s/log", dotrosdir);
+    if (!rcutils_mkdir(logdir)) {
+      return RC_LOGGING_RET_ERROR;
+    }
+
+    // Now get the milliseconds since the epoch in the local timezone.
+    rcutils_time_point_value_t now;
+    rcutils_ret_t ret = rcutils_system_time_now(&now);
+    if (ret != RCUTILS_RET_OK) {
+      // We couldn't get the system time, so get out of here without setting up
+      // logging.
+      return RC_LOGGING_RET_ERROR;
+    }
+    int64_t ms_since_epoch = RCUTILS_NS_TO_MS(now);
+
+    // Get the program name.
+    char *basec = rcutils_get_executable_name(allocator);
+    if (basec == NULL) {
+      // We couldn't get the program name, so get out of here without setting up
+      // logging.
+      return RC_LOGGING_RET_ERROR;
+    }
+
+    char log_name_buffer[512] = {0};
+    snprintf(log_name_buffer, sizeof(log_name_buffer), "%s/%s_%i_%" PRId64 ".log", logdir, basec, rcutils_get_pid(), ms_since_epoch);
+    allocator.deallocate(basec, allocator.state);
+
+    g_root_logger = spdlog::basic_logger_mt("root", log_name_buffer);
+    g_root_logger->set_pattern("%v");
+  }
+
+  return RC_LOGGING_RET_OK;
+}
+
+rcl_logging_ret_t rcl_logging_external_shutdown()
+{
+  g_root_logger = nullptr;
+  return RC_LOGGING_RET_OK;
+}
+
+void rcl_logging_external_log(int severity, const char * name, const char * msg)
+{
+  (void)name;
+  g_root_logger->log(map_external_log_level_to_library_level(severity), msg);
+}
+
+rcl_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level)
+{
+  (void)name;
+
+  g_root_logger->set_level(map_external_log_level_to_library_level(level));
+
+  return RC_LOGGING_RET_OK;
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cerrno>
-#include <memory>
-#include <mutex>
-#include <inttypes.h>
-
 #include <rcutils/allocator.h>
 #include <rcutils/filesystem.h>
 #include <rcutils/get_env.h>
@@ -25,13 +20,18 @@
 #include <rcutils/snprintf.h>
 #include <rcutils/time.h>
 
+#include <cerrno>
+#include <cinttypes>
+#include <memory>
+#include <mutex>
+
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/basic_file_sink.h"
 
 #include "rcl_logging_spdlog/logging_interface.h"
 
-#define RC_LOGGING_RET_OK    (0)
-#define RC_LOGGING_RET_ERROR (2)
+#define RCL_LOGGING_RET_OK    (0)
+#define RCL_LOGGING_RET_ERROR (2)
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,33 +59,36 @@ static spdlog::level::level_enum map_external_log_level_to_library_level(int ext
   return level;
 }
 
-rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcutils_allocator_t allocator)
+rcl_logging_ret_t rcl_logging_external_initialize(
+  const char * config_file,
+  rcutils_allocator_t allocator)
 {
   std::lock_guard<std::mutex> lk(g_logger_mutex);
   // It is possible for this to get called more than once in a process (some of
   // the tests do this implicitly by calling rclcpp::init more than once).
   // If the logger is already setup, don't do anything.
   if (g_root_logger != nullptr) {
-    return RC_LOGGING_RET_OK;
+    return RCL_LOGGING_RET_OK;
   }
 
   bool config_file_provided = (nullptr != config_file) && (config_file[0] != '\0');
   if (config_file_provided) {
     // TODO(clalancette): implement support for an external configuration file.
-    RCUTILS_SET_ERROR_MSG("spdlog logging backend doesn't currently support external configuration");
-    return RC_LOGGING_RET_ERROR;
+    RCUTILS_SET_ERROR_MSG(
+      "spdlog logging backend doesn't currently support external configuration");
+    return RCL_LOGGING_RET_ERROR;
   } else {
     // To be compatible with ROS 1, we construct a default filename of
     // the form ~/.ros/log/<exe>_<pid>_<milliseconds-since-epoch>.log
 
     // First get the home directory.
-    const char *homedir = rcutils_get_home_dir();
-    if (homedir == NULL) {
+    const char * homedir = rcutils_get_home_dir();
+    if (homedir == nullptr) {
       // We couldn't get the home directory; it is not really going to be
       // possible to do logging properly, so get out of here without setting
       // up logging.
       RCUTILS_SET_ERROR_MSG("Failed to get users home directory");
-      return RC_LOGGING_RET_ERROR;
+      return RCL_LOGGING_RET_ERROR;
     }
 
     // SPDLOG doesn't automatically create the log directories, so make them
@@ -94,21 +97,21 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
     int print_ret = rcutils_snprintf(name_buffer, sizeof(name_buffer), "%s/.ros", homedir);
     if (print_ret < 0) {
       RCUTILS_SET_ERROR_MSG("Failed to create home directory string");
-      return RC_LOGGING_RET_ERROR;
+      return RCL_LOGGING_RET_ERROR;
     }
     if (!rcutils_mkdir(name_buffer)) {
       RCUTILS_SET_ERROR_MSG("Failed to create user .ros directory");
-      return RC_LOGGING_RET_ERROR;
+      return RCL_LOGGING_RET_ERROR;
     }
 
     print_ret = rcutils_snprintf(name_buffer, sizeof(name_buffer), "%s/.ros/log", homedir);
     if (print_ret < 0) {
       RCUTILS_SET_ERROR_MSG("Failed to create log directory string");
-      return RC_LOGGING_RET_ERROR;
+      return RCL_LOGGING_RET_ERROR;
     }
     if (!rcutils_mkdir(name_buffer)) {
       RCUTILS_SET_ERROR_MSG("Failed to create user log directory");
-      return RC_LOGGING_RET_ERROR;
+      return RCL_LOGGING_RET_ERROR;
     }
 
     // Now get the milliseconds since the epoch in the local timezone.
@@ -118,37 +121,39 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
       // We couldn't get the system time, so get out of here without setting up
       // logging.  We don't need to call RCUTILS_SET_ERROR_MSG either since
       // rcutils_system_time_now() already did it.
-      return RC_LOGGING_RET_ERROR;
+      return RCL_LOGGING_RET_ERROR;
     }
     int64_t ms_since_epoch = RCUTILS_NS_TO_MS(now);
 
     // Get the program name.
-    char *basec = rcutils_get_executable_name(allocator);
-    if (basec == NULL) {
+    char * basec = rcutils_get_executable_name(allocator);
+    if (basec == nullptr) {
       // We couldn't get the program name, so get out of here without setting up
       // logging.
       RCUTILS_SET_ERROR_MSG("Failed to get the executable name");
-      return RC_LOGGING_RET_ERROR;
+      return RCL_LOGGING_RET_ERROR;
     }
 
-    print_ret = rcutils_snprintf(name_buffer, sizeof(name_buffer), "%s/.ros/log/%s_%i_%" PRId64 ".log", homedir, basec, rcutils_get_pid(), ms_since_epoch);
+    print_ret = rcutils_snprintf(name_buffer, sizeof(name_buffer),
+        "%s/.ros/log/%s_%i_%" PRId64 ".log", homedir,
+        basec, rcutils_get_pid(), ms_since_epoch);
     allocator.deallocate(basec, allocator.state);
     if (print_ret < 0) {
       RCUTILS_SET_ERROR_MSG("Failed to create log file name string");
-      return RC_LOGGING_RET_ERROR;
+      return RCL_LOGGING_RET_ERROR;
     }
     g_root_logger = spdlog::basic_logger_mt("root", name_buffer);
     g_root_logger->set_pattern("%v");
   }
 
-  return RC_LOGGING_RET_OK;
+  return RCL_LOGGING_RET_OK;
 }
 
 rcl_logging_ret_t rcl_logging_external_shutdown()
 {
   g_root_logger = nullptr;
   spdlog::drop("root");
-  return RC_LOGGING_RET_OK;
+  return RCL_LOGGING_RET_OK;
 }
 
 void rcl_logging_external_log(int severity, const char * name, const char * msg)
@@ -163,7 +168,7 @@ rcl_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int l
 
   g_root_logger->set_level(map_external_log_level_to_library_level(level));
 
-  return RC_LOGGING_RET_OK;
+  return RCL_LOGGING_RET_OK;
 }
 
 #ifdef __cplusplus

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -20,6 +20,7 @@
 #include <rcutils/allocator.h>
 #include <rcutils/filesystem.h>
 #include <rcutils/get_env.h>
+#include <rcutils/logging.h>
 #include <rcutils/process.h>
 #include <rcutils/snprintf.h>
 #include <rcutils/time.h>
@@ -29,8 +30,8 @@
 
 #include "rcl_logging_spdlog/logging_interface.h"
 
-#define RC_LOGGING_RET_OK                          (0)
-#define RC_LOGGING_RET_ERROR                       (2)
+#define RC_LOGGING_RET_OK    (0)
+#define RC_LOGGING_RET_ERROR (2)
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,33 +40,20 @@ extern "C" {
 static std::mutex g_logger_mutex;
 static std::shared_ptr<spdlog::logger> g_root_logger = nullptr;
 
-/* These are defined here to match the severity levels in rcl. They provide a consistent way for external logger
-    implementations to map between the incoming integer severity from ROS to the concept of DEBUG, INFO, WARN, ERROR,
-    and FATAL*/
-enum RC_LOGGING_LOG_SEVERITY
-{
-  RC_LOGGING_SEVERITY_UNSET = 0,  ///< The unset log level
-  RC_LOGGING_SEVERITY_DEBUG = 10,  ///< The debug log level
-  RC_LOGGING_SEVERITY_INFO = 20,  ///< The info log level
-  RC_LOGGING_SEVERITY_WARN = 30,  ///< The warn log level
-  RC_LOGGING_SEVERITY_ERROR = 40,  ///< The error log level
-  RC_LOGGING_SEVERITY_FATAL = 50,  ///< The fatal log level
-};
-
 static spdlog::level::level_enum map_external_log_level_to_library_level(int external_level)
 {
   spdlog::level::level_enum level;
 
   // map to the next highest level of severity
-  if (external_level <= RC_LOGGING_SEVERITY_DEBUG) {
+  if (external_level <= RCUTILS_LOG_SEVERITY_DEBUG) {
     level = spdlog::level::level_enum::debug;
-  } else if (external_level <= RC_LOGGING_SEVERITY_INFO) {
+  } else if (external_level <= RCUTILS_LOG_SEVERITY_INFO) {
     level = spdlog::level::level_enum::info;
-  } else if (external_level <= RC_LOGGING_SEVERITY_WARN) {
+  } else if (external_level <= RCUTILS_LOG_SEVERITY_WARN) {
     level = spdlog::level::level_enum::warn;
-  } else if (external_level <= RC_LOGGING_SEVERITY_ERROR) {
+  } else if (external_level <= RCUTILS_LOG_SEVERITY_ERROR) {
     level = spdlog::level::level_enum::err;
-  } else if (external_level <= RC_LOGGING_SEVERITY_FATAL) {
+  } else if (external_level <= RCUTILS_LOG_SEVERITY_FATAL) {
     level = spdlog::level::level_enum::critical;
   }
   return level;
@@ -84,6 +72,7 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
   bool config_file_provided = (nullptr != config_file) && (config_file[0] != '\0');
   if (config_file_provided) {
     // TODO(clalancette): implement support for an external configuration file.
+    RCUTILS_SET_ERROR_MSG("spdlog logging backend doesn't currently support external configuration");
     return RC_LOGGING_RET_ERROR;
   } else {
     // To be compatible with ROS 1, we construct a default filename of
@@ -95,6 +84,7 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
       // We couldn't get the home directory; it is not really going to be
       // possible to do logging properly, so get out of here without setting
       // up logging.
+      RCUTILS_SET_ERROR_MSG("Failed to get users home directory");
       return RC_LOGGING_RET_ERROR;
     }
 
@@ -103,17 +93,21 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
     char name_buffer[4096] = {0};
     int print_ret = rcutils_snprintf(name_buffer, sizeof(name_buffer), "%s/.ros", homedir);
     if (print_ret < 0) {
+      RCUTILS_SET_ERROR_MSG("Failed to create home directory string");
       return RC_LOGGING_RET_ERROR;
     }
     if (!rcutils_mkdir(name_buffer)) {
+      RCUTILS_SET_ERROR_MSG("Failed to create user .ros directory");
       return RC_LOGGING_RET_ERROR;
     }
 
     print_ret = rcutils_snprintf(name_buffer, sizeof(name_buffer), "%s/.ros/log", homedir);
     if (print_ret < 0) {
+      RCUTILS_SET_ERROR_MSG("Failed to create log directory string");
       return RC_LOGGING_RET_ERROR;
     }
     if (!rcutils_mkdir(name_buffer)) {
+      RCUTILS_SET_ERROR_MSG("Failed to create user log directory");
       return RC_LOGGING_RET_ERROR;
     }
 
@@ -122,7 +116,8 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
     rcutils_ret_t ret = rcutils_system_time_now(&now);
     if (ret != RCUTILS_RET_OK) {
       // We couldn't get the system time, so get out of here without setting up
-      // logging.
+      // logging.  We don't need to call RCUTILS_SET_ERROR_MSG either since
+      // rcutils_system_time_now() already did it.
       return RC_LOGGING_RET_ERROR;
     }
     int64_t ms_since_epoch = RCUTILS_NS_TO_MS(now);
@@ -132,12 +127,14 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
     if (basec == NULL) {
       // We couldn't get the program name, so get out of here without setting up
       // logging.
+      RCUTILS_SET_ERROR_MSG("Failed to get the executable name");
       return RC_LOGGING_RET_ERROR;
     }
 
     print_ret = rcutils_snprintf(name_buffer, sizeof(name_buffer), "%s/.ros/log/%s_%i_%" PRId64 ".log", homedir, basec, rcutils_get_pid(), ms_since_epoch);
     allocator.deallocate(basec, allocator.state);
     if (print_ret < 0) {
+      RCUTILS_SET_ERROR_MSG("Failed to create log file name string");
       return RC_LOGGING_RET_ERROR;
     }
     g_root_logger = spdlog::basic_logger_mt("root", name_buffer);

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -149,10 +149,8 @@ rcl_logging_ret_t rcl_logging_external_initialize(const char * config_file, rcut
 
 rcl_logging_ret_t rcl_logging_external_shutdown()
 {
-  // We could consider setting the root logger to nullptr here, and attempt to
-  // cleanup for the next time.  spdlog doesn't expect to be destructed, so
-  // we just do nothing here and rely on it already being setup for
-  // reinitialization if necessary.
+  g_root_logger = nullptr;
+  spdlog::drop("root");
   return RC_LOGGING_RET_OK;
 }
 


### PR DESCRIPTION
Along with ros2/rcutils#166 and ros2/rcl#466, this PR is one way we could implement per-process logging in ROS 2.  It uses a header-only C++ library called [spdlog](https://github.com/gabime/spdlog) instead of log4cxx (which has a bunch of problems).  I'm not at all tied to using this library, but it is relatively straightforward and has most of the features we want.  The open questions with this PR (in rough order of priority):

1.  Is spdlog good enough for our purposes?  It supports all of the features of log4cxx that we were using, with the exception of external configuration.  It just doesn't have a way to be configured from a file.  We could define something, we could ignore the feature, or we could find another C++ logging library that has that feature.
1.  When running a simple executable with this in place (`ros2 run demo_nodes_cpp talker`), you get 2 things in `~/.ros/log`; a directory of `<date>-<hostname>-<pid>`, and a log file of `<processname>-<pid>-<ms-since-epoch>`.  This PR creates the latter; I'm not sure where the former is coming from.  We should figure out our strategy here and only make one of them show up.
1.  Assuming we want to use spdlog, how do we want to vendor it?  Here I've copied it into the repository with a LICENSE file (and made the license of the package match), but we could also `ExternalProject` it or do `spdlog_vendor` package separately.
1.  Needs to be tested with Windows, macOS, etc.  I'll hold off on this until the points above are addressed.

@ros2/team @nburek FYI.