### PR TITLE
spdlog is a header-only library, so the exported dep isn't needed.

### DIFF
--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -47,6 +47,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_dependencies(ament_cmake rcutils spdlog)
+ament_export_dependencies(ament_cmake rcutils)
 ament_export_libraries(${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
Remove it here.  This should allow downstream packages to
build properly.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>