### PR TITLE
Fix Clang warning about possible uninitialized variable

### DIFF
--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -42,7 +42,7 @@ static std::shared_ptr<spdlog::logger> g_root_logger = nullptr;
 
 static spdlog::level::level_enum map_external_log_level_to_library_level(int external_level)
 {
-  spdlog::level::level_enum level;
+  spdlog::level::level_enum level = spdlog::level::level_enum::off;
 
   // map to the next highest level of severity
   if (external_level <= RCUTILS_LOG_SEVERITY_DEBUG) {


### PR DESCRIPTION
See warning: https://ci.ros2.org/job/ci_osx/6754/warnings11Result/

macOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6758)](https://ci.ros2.org/job/ci_osx/6758/)