### PR TITLE
fix initialized warning

### DIFF
--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -42,7 +42,7 @@ static std::shared_ptr<spdlog::logger> g_root_logger = nullptr;
 
 static spdlog::level::level_enum map_external_log_level_to_library_level(int external_level)
 {
-  spdlog::level::level_enum level;
+  spdlog::level::level_enum level = spdlog::level::level_enum::info;
 
   // map to the next highest level of severity
   if (external_level <= RCUTILS_LOG_SEVERITY_DEBUG) {


### PR DESCRIPTION
I get warnings on OSX for this.
If non of the cases in the `if/else` tree kicks in, the `level` variable is uninitialized. I am up for opinions, I thought it makes sense to default to `info`.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>