### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
+++ b/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
@@ -139,9 +139,10 @@ rcl_logging_ret_t rcl_logging_external_initialize(
     }
 
     char log_name_buffer[512] = {0};
-    int print_ret = rcutils_snprintf(log_name_buffer, sizeof(log_name_buffer),
-        "%s/.ros/log/%s_%i_%" PRId64 ".log", homedir, executable_name,
-        rcutils_get_pid(), ms_since_epoch);
+    int print_ret = rcutils_snprintf(
+      log_name_buffer, sizeof(log_name_buffer),
+      "%s/.ros/log/%s_%i_%" PRId64 ".log", homedir, executable_name,
+      rcutils_get_pid(), ms_since_epoch);
     allocator.deallocate(executable_name, allocator.state);
     if (print_ret < 0) {
       RCUTILS_SET_ERROR_MSG("Failed to create log file name string");
@@ -149,8 +150,8 @@ rcl_logging_ret_t rcl_logging_external_initialize(
     }
     std::string log_name_str(log_name_buffer);
     LOG4CXX_DECODE_CHAR(log_name_l4cxx_str, log_name_str);
-    log4cxx::FileAppenderPtr file_appender(new log4cxx::FileAppender(layout, log_name_l4cxx_str,
-      true));
+    log4cxx::FileAppenderPtr file_appender(
+      new log4cxx::FileAppender(layout, log_name_l4cxx_str, true));
     root_logger->addAppender(file_appender);
   }
 

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -135,9 +135,10 @@ rcl_logging_ret_t rcl_logging_external_initialize(
       return RCL_LOGGING_RET_ERROR;
     }
 
-    print_ret = rcutils_snprintf(name_buffer, sizeof(name_buffer),
-        "%s/.ros/log/%s_%i_%" PRId64 ".log", homedir,
-        basec, rcutils_get_pid(), ms_since_epoch);
+    print_ret = rcutils_snprintf(
+      name_buffer, sizeof(name_buffer),
+      "%s/.ros/log/%s_%i_%" PRId64 ".log", homedir,
+      basec, rcutils_get_pid(), ms_since_epoch);
     allocator.deallocate(basec, allocator.state);
     if (print_ret < 0) {
       RCUTILS_SET_ERROR_MSG("Failed to create log file name string");


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.