### PR TITLE
Make spdlog an exec_depend.

### DIFF
--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -47,6 +47,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_dependencies(ament_cmake rcutils)
+ament_export_dependencies(ament_cmake rcutils spdlog_vendor spdlog)
 ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/rcl_logging_spdlog/package.xml
+++ b/rcl_logging_spdlog/package.xml
@@ -15,6 +15,9 @@
 
   <depend>rcutils</depend>
 
+  <exec_depend>spdlog_vendor</exec_depend>
+  <exec_depend>spdlog</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
Newer spdlog (>= 1.5.0) builds a shared library, so we
need to add an exec_depend now.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Part of solving https://github.com/ros2/rcl_logging/issues/26