### PR TITLE
Current state Quality Declaration, Contributing and Readme files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+Any contribution that you make to this repository will
+be under the Apache 2 License, as dictated by that
+[license](http://www.apache.org/licenses/LICENSE-2.0.html):
+
+~~~
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+~~~
+
+Contributors must sign-off each commit by adding a `Signed-off-by: ...`
+line to commit messages to certify that they have the right to submit
+the code they are contributing to the project according to the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+This repository contains several packages which are all related to the ROS logging functionalities.
+
+### Packages
+
+#### rcl_logging_spdlog
+
+Package supporting an implementation of logging functionality using `spdlog`.
+
+This package claims to be in the **Quality Level 1** category, see the [Quality Declaration](./rcl_logging_spdlog/Quality_Declaration.md) for more details.
+
+#### rcl_logging_log4cxx
+
+Package supporting an implementation of logging functionality using `log4cxx`.
+
+#### rcl_logging_noop
+
+Package supporting a logging implementation that does nothing with the log messages.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,7 @@
 This repository contains several packages which are all related to the ROS logging functionalities.
 
-### Packages
+## Packages
 
-#### rcl_logging_spdlog
-
-Package supporting an implementation of logging functionality using `spdlog`.
-
-This package claims to be in the **Quality Level 1** category, see the [Quality Declaration](./rcl_logging_spdlog/Quality_Declaration.md) for more details.
-
-#### rcl_logging_log4cxx
-
-Package supporting an implementation of logging functionality using `log4cxx`.
-
-#### rcl_logging_noop
-
-Package supporting a logging implementation that does nothing with the log messages.
+- rcl_logging_spdlog
+- rcl_logging_log4cxx
+- rcl_logging_noop

--- a/rcl_logging_spdlog/Quality_Declaration.md
+++ b/rcl_logging_spdlog/Quality_Declaration.md
@@ -1,0 +1,120 @@
+
+This document is a declaration of software quality for the `rcl_logging_spdlog` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rcl_logging_spdlog` Quality Declaration
+
+The package `rcl_logging_spdlog` claims to be in the **Quality Level 1** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy
+
+### Version Scheme
+TODO: dump to 1.0
+
+`rcl_logging_spdlog` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning), and is at or above a stable version, i.e. `>= 1.0.0`.
+
+### API Stability Within a Released ROS Distribution
+
+`rcl_logging_spdlog` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution
+
+`rcl_logging_spdlog` contains C++ code and therefore must be concerned with ABI stability, and will maintain ABI stability within a ROS distribution.
+
+### Public API Declaration
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package, headers in any other folders are not installed and considered private.
+
+## Change Control Process
+
+`rcl_logging_spdlog` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process).
+
+This includes:
+
+- all changes occur through a pull request
+- all pull request have two peer reviews
+- all pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
+- all pull request must resolve related documentation changes before merging
+
+## Documentation
+
+### Feature Documentation
+
+TODO: Add features and then fix link
+
+`rcl_logging_spdlog` has a [feature list](TODO) and each item in the list links to the corresponding feature documentation.
+There is documentation for all of the features, and new features require documentation before being added.
+
+### Public API Documentation
+
+TODO fix link
+
+`rcl_logging_spdlog` has embedded API documentation and it is generated using doxygen and is [hosted](TODO) along side the feature documentation.
+There is documentation for all of the public API, and new additions to the public API require documentation before being added.
+
+### License
+
+The license for `rcl_logging_spdlog` is Apache 2.0, and a summary is in each source file, the type is declared in the `package.xml` manifest file, and a full copy of the license is in the `LICENSE` file.
+
+There is an automated test which runs a linter (ament_lint_common) that ensures each file has a license statement.
+
+### Copyright Statements
+
+The copyright holders each provide a statement of copyright in each source code file in `rcl_logging_spdlog`.
+
+There is an automated test which runs a linter (ament_lint_common) that ensures each file has at least one copyright statement.
+
+## Testing
+
+### Feature Testing
+TODO: Add unit tests for the package
+
+Each feature in `rcl_logging_spdlog` has corresponding tests which simulate typical usage, and they are located in the `test` directory.
+New features are required to have tests before being added.
+
+### Public API Testing
+TODO: Add unit tests for the package
+
+Each part of the public API have tests, and new additions or changes to the public API require tests before being added.
+The tests aim to cover both typical usage and corner cases, but are quantified by contributing to code coverage.
+
+### Coverage
+
+`rcl_logging_spdlog` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#coverage), and opts to use line coverage instead of branch coverage.
+
+Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
+
+Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/55/cobertura/src_ros2_rcl_logging_rcl_logging_spdlog_src/):
+
+### Performance
+
+`rcl_logging_spdlog` follows the recommendations for performance testing of C++ code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance), and opts to do performance analysis on each release rather than each change.
+
+TODO how to run perf tests, where do they live, etc. will this package apply to perf tests?
+
+### Linters and Static Analysis
+
+`rcl_logging_spdlog` uses and passes all the standard linters and static analysis tools for a C++ package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis).
+
+TODO any qualifications on what "passing" means for certain linters
+
+## Dependencies
+TODO: fix links to latest version of Quality declaration of each
+
+`rcl_logging_spdlog` depends on the ROS packages `rcutils` and `spdlog_vendor`. It also depends on the external dependency `spdlog`.
+
+`rcutils` was declared to be Quality Level 1 [here](https://github.com/ros2/rcutils/blob/quality_declaration/QUALITY_DECLARATION.md).
+
+`spdlog_vendor` was declared to be Quality Level 1 [here](TODO).
+
+`spdlog` as external dependency was declared to be Quality Level 1 [here](TODO)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+It also has several test dependencies, which do not affect the resulting quality of the package, because they are only used to build and run the test code.
+
+## Platform Support
+
+`rcl_logging_spdlog` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.

--- a/rcl_logging_spdlog/Quality_Declaration.md
+++ b/rcl_logging_spdlog/Quality_Declaration.md
@@ -137,7 +137,9 @@ Below are evaluations of each of `rcl_logging_spdlog`'s run-time and build-time 
 
 `rcl_logging_spdlog` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
 
-## Vulnerability Disclosure Policy [7.i]
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
 
 `rcl_logging_spdlog` does not have a Vulnerability Disclosure Policy.
 

--- a/rcl_logging_spdlog/Quality_Declaration.md
+++ b/rcl_logging_spdlog/Quality_Declaration.md
@@ -1,120 +1,185 @@
-
 This document is a declaration of software quality for the `rcl_logging_spdlog` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 # `rcl_logging_spdlog` Quality Declaration
 
-The package `rcl_logging_spdlog` claims to be in the **Quality Level 1** category.
+The package `rcl_logging_spdlog` claims to be in the **Quality Level 4** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Quality Categories in REP-2004](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-quality-categories) of the ROS2 developer guide.
 
-## Version Policy
+## Version Policy [1]
 
-### Version Scheme
-TODO: dump to 1.0
+### Version Scheme [1.i]
 
-`rcl_logging_spdlog` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning), and is at or above a stable version, i.e. `>= 1.0.0`.
+`rcl_logging_spdlog` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
 
-### API Stability Within a Released ROS Distribution
+### Version Stability [1.ii]
 
-`rcl_logging_spdlog` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+Currently this package it is not at or above a stable version, i.e. `>= 1.0.0`.
 
-### ABI Stability Within a Released ROS Distribution
-
-`rcl_logging_spdlog` contains C++ code and therefore must be concerned with ABI stability, and will maintain ABI stability within a ROS distribution.
-
-### Public API Declaration
+### Public API Declaration [1.iii]
 
 All symbols in the installed headers are considered part of the public API.
 
-All installed headers are in the `include` directory of the package, headers in any other folders are not installed and considered private.
+All installed headers are in the [include](./include/rcl_logging_spdlog) directory of the package, headers in any other folders are not installed and considered private.
 
-## Change Control Process
+### API Stability Policy [1.iv]
+
+`rcl_logging_spdlog` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Policy [1.v]
+
+`rcl_logging_spdlog` contains C code and therefore must be concerned with ABI stability, and will maintain ABI stability within a ROS distribution.
+
+### ABI and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rcl_logging_spdlog` will not break API nor ABI within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+## Change Control Process [2]
 
 `rcl_logging_spdlog` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process).
 
-This includes:
+### Change Requests [2.i]
 
-- all changes occur through a pull request
-- all pull request have two peer reviews
-- all pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
-- all pull request must resolve related documentation changes before merging
+All changes will occur through a pull request, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
-## Documentation
+### Contributor Origin [2.ii]
 
-### Feature Documentation
+This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](./CONTRIBUTING.md)
 
-TODO: Add features and then fix link
+### Peer Review Policy [2.iii]
+All pull requests will be peer-reviewed, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
-`rcl_logging_spdlog` has a [feature list](TODO) and each item in the list links to the corresponding feature documentation.
-There is documentation for all of the features, and new features require documentation before being added.
+### Continuous Integration [2.iv]
 
-### Public API Documentation
+All pull requests must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
 
-TODO fix link
+Currently nightly results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/rcl_logging_spdlog/)
+* [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rcl_logging_spdlog/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/rcl_logging_spdlog/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/rcl_logging_spdlog/)
 
-`rcl_logging_spdlog` has embedded API documentation and it is generated using doxygen and is [hosted](TODO) along side the feature documentation.
-There is documentation for all of the public API, and new additions to the public API require documentation before being added.
+###  Documentation Policy [2.v]
 
-### License
+All pull requests must resolve related documentation changes before merging.
 
-The license for `rcl_logging_spdlog` is Apache 2.0, and a summary is in each source file, the type is declared in the `package.xml` manifest file, and a full copy of the license is in the `LICENSE` file.
+## Documentation [3]
 
-There is an automated test which runs a linter (ament_lint_common) that ensures each file has a license statement.
+### Feature Documentation [3.i]
 
-### Copyright Statements
+`rcl_logging_spdlog` does not have feature documentation.
+
+### Public API Documentation [3.ii]
+
+`rcl_logging_spdlog` does not have public API documentation.
+
+### License [3.iii]
+
+The license for `rcl_logging_spdlog` is Apache 2.0, and a summary is in each source file, the type is declared in the [`package.xml`](./package.xml) manifest file, and a full copy of the license is in the [`LICENSE`](../LICENSE) file.
+
+There is an automated test which runs a linter that ensures each file has a license statement. [Here](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rcl_logging_spdlog/) can be found a list with the latest results of the various linters being run on the package.
+
+### Copyright Statements [3.iv]
 
 The copyright holders each provide a statement of copyright in each source code file in `rcl_logging_spdlog`.
 
-There is an automated test which runs a linter (ament_lint_common) that ensures each file has at least one copyright statement.
+There is an automated test which runs a linter that ensures each file has at least one copyright statement. Latest linter result report can be seen [here](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rcl_logging_spdlog/copyright/).
 
-## Testing
+## Testing [4]
 
-### Feature Testing
-TODO: Add unit tests for the package
+### Feature Testing [4.i]
 
-Each feature in `rcl_logging_spdlog` has corresponding tests which simulate typical usage, and they are located in the `test` directory.
-New features are required to have tests before being added.
+`rcl_logging_spdlog` does not include feature testing.
 
-### Public API Testing
-TODO: Add unit tests for the package
+### Public API Testing [4.ii]
 
-Each part of the public API have tests, and new additions or changes to the public API require tests before being added.
-The tests aim to cover both typical usage and corner cases, but are quantified by contributing to code coverage.
+`rcl_logging_spdlog` does not include Public API testing.
 
-### Coverage
+### Coverage [4.iii]
 
-`rcl_logging_spdlog` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#coverage), and opts to use line coverage instead of branch coverage.
+`rcl_logging_spdlog` does not include tests, so coverage is not provided.
 
-Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
+### Performance [4.iv]
 
-Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/55/cobertura/src_ros2_rcl_logging_rcl_logging_spdlog_src/):
+`rcl_logging_spdlog` does not conduct performance tests.
 
-### Performance
+### Linters and Static Analysis [4.v]
 
-`rcl_logging_spdlog` follows the recommendations for performance testing of C++ code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance), and opts to do performance analysis on each release rather than each change.
+`rcl_logging_spdlog` uses and passes all the standard linters and static analysis tools for a C+ package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis). Passing implies there are no linter/static errors when testing against CI of supported platforms.
 
-TODO how to run perf tests, where do they live, etc. will this package apply to perf tests?
+Currently nightly results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/rcl_logging_spdlog/)
+* [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rcl_logging_spdlog/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/rcl_logging_spdlog/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/rcl_logging_spdlog/)
 
-### Linters and Static Analysis
+## Dependencies [5]
 
-`rcl_logging_spdlog` uses and passes all the standard linters and static analysis tools for a C++ package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis).
+Below are evaluations of each of `rcl_logging_spdlog`'s run-time and build-time dependencies that have been determined to influence the quality.
 
-TODO any qualifications on what "passing" means for certain linters
+`rcl_logging_spdlog` depends on the ROS packages `rcutils` and `spdlog_vendor`.
 
-## Dependencies
-TODO: fix links to latest version of Quality declaration of each
+`rcutils` was declared to be Quality Level 4 [here](https://github.com/ros2/rcutils/blob/master/QUALITY_DECLARATION.md).
 
-`rcl_logging_spdlog` depends on the ROS packages `rcutils` and `spdlog_vendor`. It also depends on the external dependency `spdlog`.
+`spdlog_vendor` was declared to be Quality Level 4 [here](https://github.com/ros2/spdlog_vendor/blob/master/Quality_Declaration.md).
 
-`rcutils` was declared to be Quality Level 1 [here](https://github.com/ros2/rcutils/blob/quality_declaration/QUALITY_DECLARATION.md).
+### Optional Direct Runtime ROS Dependencies [5.ii]
 
-`spdlog_vendor` was declared to be Quality Level 1 [here](TODO).
+`rcl_logging_spdlog` has no optional Direct Runtime ROS dependencies that need to be considered for this declaration.
 
-`spdlog` as external dependency was declared to be Quality Level 1 [here](TODO)
+### Direct Runtime non-ROS Dependency [5.iii]
 
-It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
-It also has several test dependencies, which do not affect the resulting quality of the package, because they are only used to build and run the test code.
+`rcl_logging_spdlog` has a Direct Runtime non-ROS dependenciy the `spdlog` library. It was declared to be Quality Level 4 [here](https://github.com/ros2/spdlog_vendor/blob/master/SPDLOG_QUALITY_DECLARATION.md).
 
-## Platform Support
+
+## Platform Support [6]
 
 `rcl_logging_spdlog` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
+
+## Vulnerability Disclosure Policy [7.i]
+
+`rcl_logging_spdlog` does not have a Vulnerability Disclosure Policy.
+
+# Current status Summary
+
+The chart below compares the requirements in the REP-2004 with the current state of the `rcl` package.
+
+|Number|  Requirement| Current state |
+|--|--|--|
+|1| **Version policy** |---|
+|1.i|Version Policy available | ✓ |
+|1.ii|Stable version |☓|
+|1.iii|Declared public API|✓|
+|1.iv|API stability policy|✓|
+|1.v|ABI stability policy|✓|
+|1.vi_|API/ABI stable within ros distribution|✓|
+|2| **Change control process** |---|
+|2.i| All changes occur on change request | ✓|
+|2.ii| Contributor origin (DCO, CLA, etc) | ✓|
+|2.iii| Peer review policy | ✓ |
+|2.iv| CI policy for change requests | ✓ |
+|2.v| Documentation policy for change requests | ✓ |
+|3| **Documentation** | --- |
+|3.i| Per feature documentation | ☓ |
+|3.ii| Per public API item documentation | ☓ |
+|3.iii| Declared License(s) | ✓ |
+|3.iv| Copyright in source files| ✓ |
+|3.v.a| Quality declaration linked to README | ✓ |
+|3.v.b| Centralized declaration available for peer review |✓|
+|4| Testing | --- |
+|4.i| Feature items tests | ☓ |
+|4.ii| Public API tests | ☓ |
+|4.iii.a| Using coverage | ☓ |
+|4.iii.a| Coverage policy | ☓ |
+|4.iv.a| Performance tests (if applicable) | ☓ |
+|4.iv.b| Performance tests policy| ✓ |
+|4.v.a| Code style enforcement (linters)| ✓ |
+|4.v.b| Use of static analysis tools | ✓ |
+|5| Dependencies | --- |
+|5.i| Must not have ROS lower level dependencies | ✓ |
+|5.ii| Optional ROS lower level dependencies| ✓ |
+|5.iii| Justifies quality use of non-ROS dependencies |✓|
+|6| Platform support | --- |
+|6.i| Support targets Tier1 ROS platforms| ✓ |
+|7| Security | --- |
+|7.i| Vulnerability Disclosure Policy | ☓ |

--- a/rcl_logging_spdlog/Quality_Declaration.md
+++ b/rcl_logging_spdlog/Quality_Declaration.md
@@ -1,4 +1,4 @@
-This document is a declaration of software quality for the `rcl_logging_spdlog` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+This document is a declaration of software quality for the `rcl_logging_spdlog` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
 
 # `rcl_logging_spdlog` Quality Declaration
 
@@ -47,7 +47,8 @@ All changes will occur through a pull request, check [ROS 2 Developer Guide](htt
 This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](./CONTRIBUTING.md)
 
 ### Peer Review Policy [2.iii]
-All pull requests will be peer-reviewed, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
+
+Following the recommended guidelines in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) all pull requests must have at least 1 peer review.
 
 ### Continuous Integration [2.iv]
 
@@ -105,7 +106,7 @@ There is an automated test which runs a linter that ensures each file has at lea
 
 ### Linters and Static Analysis [4.v]
 
-`rcl_logging_spdlog` uses and passes all the standard linters and static analysis tools for a C+ package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis). Passing implies there are no linter/static errors when testing against CI of supported platforms.
+`rcl_logging_spdlog` uses and passes all the standard linters and static analysis tools for a C package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis). Passing implies there are no linter/static errors when testing against CI of supported platforms.
 
 Currently nightly results can be seen here:
 * [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/rcl_logging_spdlog/)

--- a/rcl_logging_spdlog/Quality_Declaration.md
+++ b/rcl_logging_spdlog/Quality_Declaration.md
@@ -132,7 +132,6 @@ Below are evaluations of each of `rcl_logging_spdlog`'s run-time and build-time 
 
 `rcl_logging_spdlog` has a Direct Runtime non-ROS dependenciy the `spdlog` library. It was declared to be Quality Level 4 [here](https://github.com/ros2/spdlog_vendor/blob/master/SPDLOG_QUALITY_DECLARATION.md).
 
-
 ## Platform Support [6]
 
 `rcl_logging_spdlog` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.

--- a/rcl_logging_spdlog/Quality_Declaration.md
+++ b/rcl_logging_spdlog/Quality_Declaration.md
@@ -44,7 +44,7 @@ All changes will occur through a pull request, check [ROS 2 Developer Guide](htt
 
 ### Contributor Origin [2.ii]
 
-This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](./CONTRIBUTING.md)
+This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md)
 
 ### Peer Review Policy [2.iii]
 

--- a/rcl_logging_spdlog/README.md
+++ b/rcl_logging_spdlog/README.md
@@ -1,0 +1,5 @@
+# rcl_logging_spdlog
+
+Package supporting an implementation of logging functionality using `spdlog`.
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./Quality_Declaration.md) for more details.

--- a/rcl_logging_spdlog/README.md
+++ b/rcl_logging_spdlog/README.md
@@ -2,4 +2,6 @@
 
 Package supporting an implementation of logging functionality using `spdlog`.
 
+## Quality Declaration
+
 This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./Quality_Declaration.md) for more details.


### PR DESCRIPTION
This PR adds the current Quality Declaration claim for the rcl_logging_spdlog package. The current state is Quality level 4.

It will also add Contributing.md file to properly document License contributions and Readme pointing to current Quality Declaration.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>