### PR TITLE
fix CMake warning about using uninitialized variables

### DIFF
--- a/rcl_logging_log4cxx/CMakeLists.txt
+++ b/rcl_logging_log4cxx/CMakeLists.txt
@@ -16,7 +16,7 @@ list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(Log4cxx REQUIRED)
 find_package(rcutils REQUIRED)
 
-include_directories(${ament_INCLUDE_DIRS} include)
+include_directories(include)
 
 
 if(NOT WIN32)

--- a/rcl_logging_noop/CMakeLists.txt
+++ b/rcl_logging_noop/CMakeLists.txt
@@ -14,8 +14,6 @@ endif()
 find_package(ament_cmake_ros REQUIRED)
 find_package(rcutils REQUIRED)
 
-include_directories(${ament_INCLUDE_DIRS})
-
 if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()


### PR DESCRIPTION
When invoking CMake with `--warn-uninitialized`.