### PR TITLE
Add some preliminary functional tests

### DIFF
--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -45,6 +45,12 @@ install(DIRECTORY include/${PROJECT_NAME}/
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_logging_interface test/test_logging_interface.cpp)
+  if(TARGET test_logging_interface)
+    target_link_libraries(test_logging_interface ${PROJECT_NAME})
+  endif()
 endif()
 
 ament_export_include_directories(include)

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -31,11 +31,11 @@ TEST(logging_interface, init_invalid)
   bad_allocator.allocate = bad_malloc;
 
   // Config files are not supported by spdlog
-  EXPECT_NE(0, rcl_logging_external_initialize("anything", allocator));
+  EXPECT_EQ(2, rcl_logging_external_initialize("anything", allocator));
   rcutils_reset_error();
-  EXPECT_NE(0, rcl_logging_external_initialize(nullptr, bad_allocator));
+  EXPECT_EQ(2, rcl_logging_external_initialize(nullptr, bad_allocator));
   rcutils_reset_error();
-  EXPECT_NE(0, rcl_logging_external_initialize(nullptr, invalid_allocator));
+  EXPECT_EQ(2, rcl_logging_external_initialize(nullptr, invalid_allocator));
   rcutils_reset_error();
 }
 

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -1,0 +1,35 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rcutils/allocator.h>
+#include <rcutils/error_handling.h>
+#include "rcl_logging_spdlog/logging_interface.h"
+#include "gtest/gtest.h"
+
+static void * bad_malloc(size_t, void *)
+{
+  return nullptr;
+}
+
+TEST(logging, init_invalid)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_allocator_t bad_allocator = rcutils_get_default_allocator();
+  bad_allocator.allocate = bad_malloc;
+
+  // Config files are not supported by spdlog
+  ASSERT_NE(0, rcl_logging_external_initialize("anything", allocator));
+  rcutils_reset_error();
+  ASSERT_NE(0, rcl_logging_external_initialize(nullptr, bad_allocator));
+}


### PR DESCRIPTION
Eventually we'll want to create a test to verify that we have spdlog configured correctly and can log data, but right now there aren't any good mechanisms to keep us from showering the `~/.ros/log/` directory with our log files. There also isn't a great way to determine exactly where the log ended up.

I'll follow-up with changes to add more comprehensive testing when those mechanisms are available.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10754)](http://ci.ros2.org/job/ci_linux/10754/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6149)](http://ci.ros2.org/job/ci_linux-aarch64/6149/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8756)](http://ci.ros2.org/job/ci_osx/8756/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10643)](http://ci.ros2.org/job/ci_windows/10643/)