### PR TITLE
warn about unused return value for set_logger_level

### DIFF
--- a/rcl_logging_log4cxx/include/rcl_logging_log4cxx/logging_interface.h
+++ b/rcl_logging_log4cxx/include/rcl_logging_log4cxx/logging_interface.h
@@ -35,6 +35,7 @@ RCL_LOGGING_PUBLIC
 void rcl_logging_external_log(int severity, const char * name, const char * msg);
 
 RCL_LOGGING_PUBLIC
+RCUTILS_WARN_UNUSED
 rcl_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level);
 
 

--- a/rcl_logging_spdlog/include/rcl_logging_spdlog/logging_interface.h
+++ b/rcl_logging_spdlog/include/rcl_logging_spdlog/logging_interface.h
@@ -35,6 +35,7 @@ RCL_LOGGING_PUBLIC
 void rcl_logging_external_log(int severity, const char * name, const char * msg);
 
 RCL_LOGGING_PUBLIC
+RCUTILS_WARN_UNUSED
 rcl_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level);
 
 


### PR DESCRIPTION
In combination with ros2/rcl#652.