### PR TITLE
More spdlog tests

### DIFF
--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -47,9 +47,11 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(rcpputils REQUIRED)
   ament_add_gtest(test_logging_interface test/test_logging_interface.cpp)
   if(TARGET test_logging_interface)
     target_link_libraries(test_logging_interface ${PROJECT_NAME})
+    ament_target_dependencies(test_logging_interface rcpputils)
   endif()
 endif()
 

--- a/rcl_logging_spdlog/package.xml
+++ b/rcl_logging_spdlog/package.xml
@@ -20,6 +20,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rcpputils</test_depend>
 
   <member_of_group>rcl_logging_packages</member_of_group>
 

--- a/rcl_logging_spdlog/test/fixtures.hpp
+++ b/rcl_logging_spdlog/test/fixtures.hpp
@@ -90,17 +90,16 @@ public:
     }
 
     char raw_line[2048];
-    while (fgets(raw_line, sizeof(raw_line), fp) != NULL) {
-      pclose(fp);
-
-      std::string line(raw_line);
-      fs::path line_path(line.substr(0, line.find_last_not_of(" \t\r\n") + 1));
-      // This should be changed once ros2/rcpputils#68 is resolved
-      return line_path.is_absolute() ? line_path : log_dir / line_path;
+    char * ret = fgets(raw_line, sizeof(raw_line), fp);
+    pclose(fp);
+    if (nullptr == ret) {
+      throw std::runtime_error("No log files were found");
     }
 
-    pclose(fp);
-    throw std::runtime_error("No log files were found");
+    std::string line(raw_line);
+    fs::path line_path(line.substr(0, line.find_last_not_of(" \t\r\n") + 1));
+    // This should be changed once ros2/rcpputils#68 is resolved
+    return line_path.is_absolute() ? line_path : log_dir / line_path;
   }
 
 private:
@@ -111,8 +110,7 @@ private:
       throw std::runtime_error("Failed to determine executable name");
     }
     std::stringstream prefix;
-    prefix << exe_name << "_" <<
-      rcutils_get_pid() << "_";
+    prefix << exe_name << "_" << rcutils_get_pid() << "_";
     allocator.deallocate(exe_name, allocator.state);
     return prefix.str();
   }

--- a/rcl_logging_spdlog/test/fixtures.hpp
+++ b/rcl_logging_spdlog/test/fixtures.hpp
@@ -29,6 +29,9 @@
 #ifdef _WIN32
 #define popen _popen
 #define pclose _pclose
+#define DIR_CMD "dir /B"
+#else
+#define DIR_CMD "ls -d"
 #endif
 
 namespace fs = rcpputils::fs;
@@ -79,11 +82,7 @@ public:
   {
     fs::path log_dir = get_log_dir();
     std::stringstream dir_command;
-    dir_command << "dir";
-#ifdef _WIN32
-    dir_command << " /B";
-#endif
-    dir_command << " " << (log_dir / get_expected_log_prefix()).string() << "*";
+    dir_command << DIR_CMD << " " << (log_dir / get_expected_log_prefix()).string() << "*";
 
     FILE * fp = popen(dir_command.str().c_str(), "r");
     if (nullptr == fp) {

--- a/rcl_logging_spdlog/test/fixtures.hpp
+++ b/rcl_logging_spdlog/test/fixtures.hpp
@@ -22,6 +22,7 @@
 #include <rcutils/process.h>
 #include <rcutils/types/string_array.h>
 
+#include <limits.h>
 #include <string>
 
 #include "gtest/gtest.h"
@@ -89,7 +90,11 @@ public:
       throw std::runtime_error("Failed to glob for log files");
     }
 
-    char raw_line[2048];
+#ifdef _WIN32
+    char raw_line[MAX_PATH];
+#else
+    char raw_line[PATH_MAX];
+#endif
     char * ret = fgets(raw_line, sizeof(raw_line), fp);
     pclose(fp);
     if (nullptr == ret) {

--- a/rcl_logging_spdlog/test/fixtures.hpp
+++ b/rcl_logging_spdlog/test/fixtures.hpp
@@ -1,0 +1,55 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FIXTURES_HPP_
+#define FIXTURES_HPP_
+
+#include <rcutils/allocator.h>
+#include "gtest/gtest.h"
+
+class AllocatorTest : public ::testing::Test
+{
+public:
+  AllocatorTest()
+  : allocator(rcutils_get_default_allocator()),
+    bad_allocator(get_bad_allocator()),
+    invalid_allocator(rcutils_get_zero_initialized_allocator())
+  {
+  }
+
+  rcutils_allocator_t allocator;
+  rcutils_allocator_t bad_allocator;
+  rcutils_allocator_t invalid_allocator;
+
+private:
+  static rcutils_allocator_t get_bad_allocator()
+  {
+    rcutils_allocator_t bad_allocator = rcutils_get_default_allocator();
+    bad_allocator.allocate = AllocatorTest::bad_malloc;
+    bad_allocator.reallocate = AllocatorTest::bad_realloc;
+    return bad_allocator;
+  }
+
+  static void * bad_malloc(size_t, void *)
+  {
+    return nullptr;
+  }
+
+  static void * bad_realloc(void *, size_t, void *)
+  {
+    return nullptr;
+  }
+};
+
+#endif  // FIXTURES_HPP_

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -38,6 +38,9 @@ TEST_F(LoggingTest, full_cycle)
 {
   ASSERT_EQ(0, rcl_logging_external_initialize(nullptr, allocator));
 
+  // Make sure we can call initialize more than once
+  ASSERT_EQ(0, rcl_logging_external_initialize(nullptr, allocator));
+
   std::stringstream expected_log;
   for (int level = RCUTILS_LOG_SEVERITY_UNSET; level <= RCUTILS_LOG_SEVERITY_FATAL; level += 10) {
     EXPECT_EQ(0, rcl_logging_external_set_logger_level(nullptr, level));

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -23,6 +23,16 @@
 #include "gtest/gtest.h"
 #include "rcl_logging_spdlog/logging_interface.h"
 
+const int logger_levels[] =
+{
+  RCUTILS_LOG_SEVERITY_UNSET,
+  RCUTILS_LOG_SEVERITY_DEBUG,
+  RCUTILS_LOG_SEVERITY_INFO,
+  RCUTILS_LOG_SEVERITY_WARN,
+  RCUTILS_LOG_SEVERITY_ERROR,
+  RCUTILS_LOG_SEVERITY_FATAL,
+};
+
 TEST_F(LoggingTest, init_invalid)
 {
   // Config files are not supported by spdlog
@@ -42,12 +52,10 @@ TEST_F(LoggingTest, full_cycle)
   ASSERT_EQ(0, rcl_logging_external_initialize(nullptr, allocator));
 
   std::stringstream expected_log;
-  for (int level = RCUTILS_LOG_SEVERITY_UNSET; level <= RCUTILS_LOG_SEVERITY_FATAL; level += 10) {
+  for (int level : logger_levels) {
     EXPECT_EQ(0, rcl_logging_external_set_logger_level(nullptr, level));
 
-    for (int severity = RCUTILS_LOG_SEVERITY_UNSET; severity <= RCUTILS_LOG_SEVERITY_FATAL;
-      severity += 10)
-    {
+    for (int severity : logger_levels) {
       std::stringstream ss;
       ss << "Message of severity " << severity << " at level " << level;
       rcl_logging_external_log(severity, nullptr, ss.str().c_str());

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -19,6 +19,7 @@
 #include <rcutils/error_handling.h>
 #include <rcutils/logging.h>
 
+#include <limits.h>
 #include <fstream>
 #include <string>
 
@@ -64,24 +65,22 @@ private:
 // TODO(cottsay): Remove when ros2/rcpputils#63 is resolved
 static fs::path current_path()
 {
-  char * cwd;
 #ifdef _WIN32
 #ifdef UNICODE
 #error "rcpputils::fs does not support Unicode paths"
 #endif
-  cwd = _getcwd(NULL, 0);
+  char cwd[MAX_PATH];
+  if (nullptr == _getcwd(cwd, MAX_PATH)) {
 #else
-  cwd = getcwd(NULL, 0);
+  char cwd[PATH_MAX];
+  if (nullptr == getcwd(cwd, PATH_MAX)) {
 #endif
-  if (nullptr == cwd) {
     std::error_code ec{errno, std::system_category()};
     errno = 0;
     throw std::system_error{ec, "cannot get current working directory"};
   }
 
-  std::string ret(cwd);
-  free(cwd);
-  return fs::path(ret);
+  return fs::path(cwd);
 }
 
 TEST_F(LoggingTest, init_invalid)

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -12,24 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <rcutils/allocator.h>
 #include <rcutils/error_handling.h>
 #include <rcutils/logging.h>
-#include "rcl_logging_spdlog/logging_interface.h"
+
+#include "fixtures.hpp"
 #include "gtest/gtest.h"
+#include "rcl_logging_spdlog/logging_interface.h"
 
-static void * bad_malloc(size_t, void *)
+TEST_F(AllocatorTest, init_invalid)
 {
-  return nullptr;
-}
-
-TEST(logging_interface, init_invalid)
-{
-  rcutils_allocator_t allocator = rcutils_get_default_allocator();
-  rcutils_allocator_t bad_allocator = rcutils_get_default_allocator();
-  rcutils_allocator_t invalid_allocator = rcutils_get_zero_initialized_allocator();
-  bad_allocator.allocate = bad_malloc;
-
   // Config files are not supported by spdlog
   EXPECT_EQ(2, rcl_logging_external_initialize("anything", allocator));
   rcutils_reset_error();
@@ -39,10 +30,8 @@ TEST(logging_interface, init_invalid)
   rcutils_reset_error();
 }
 
-TEST(logging_interface, full_cycle)
+TEST_F(AllocatorTest, full_cycle)
 {
-  rcutils_allocator_t allocator = rcutils_get_default_allocator();
-
   ASSERT_EQ(0, rcl_logging_external_initialize(nullptr, allocator));
   EXPECT_EQ(0, rcl_logging_external_set_logger_level(nullptr, RCUTILS_LOG_SEVERITY_INFO));
   rcl_logging_external_log(RCUTILS_LOG_SEVERITY_INFO, nullptr, "Log Message");


### PR DESCRIPTION
As suggested in [#36 (comment)](https://github.com/ros2/rcl_logging/pull/36#issuecomment-629144007), some of this approach takes after #37.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11021)](http://ci.ros2.org/job/ci_linux/11021/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6353)](http://ci.ros2.org/job/ci_linux-aarch64/6353/)
* Linux-coverage [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11021)](http://ci.ros2.org/job/ci_linux/11021/cobertura/src_ros2_rcl_logging_rcl_logging_spdlog_src/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8978)](http://ci.ros2.org/job/ci_osx/8978/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10948)](http://ci.ros2.org/job/ci_windows/10948/)