### PR TITLE
Remove unused pytest dependency.

### DIFF
--- a/rcl_logging_log4cxx/package.xml
+++ b/rcl_logging_log4cxx/package.xml
@@ -17,7 +17,6 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>launch_testing</test_depend>

--- a/rcl_logging_noop/package.xml
+++ b/rcl_logging_noop/package.xml
@@ -16,7 +16,6 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>launch_testing</test_depend>


### PR DESCRIPTION
Neither log4cxx nor the noop backends use the pytest dependency,
so remove it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is somewhat related to ros2/ros2#951, but is really just something I noticed while debugging that. CI is over in that other issue.