### PR TITLE
Include rcutils/allocator.h in logging_interface.h

### DIFF
--- a/rcl_logging_log4cxx/include/rcl_logging_log4cxx/logging_interface.h
+++ b/rcl_logging_log4cxx/include/rcl_logging_log4cxx/logging_interface.h
@@ -15,11 +15,12 @@
 #ifndef RCL_LOGGING_LOG4CXX__LOGGING_INTERFACE_H_
 #define RCL_LOGGING_LOG4CXX__LOGGING_INTERFACE_H_
 
+#include "rcl_logging_log4cxx/visibility_control.h"
+#include "rcutils/allocator.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "rcl_logging_log4cxx/visibility_control.h"
 
 typedef int rcl_logging_ret_t;
 

--- a/rcl_logging_spdlog/include/rcl_logging_spdlog/logging_interface.h
+++ b/rcl_logging_spdlog/include/rcl_logging_spdlog/logging_interface.h
@@ -19,6 +19,8 @@
 extern "C" {
 #endif
 
+#include <rcutils/allocator.h>
+
 #include "rcl_logging_spdlog/visibility_control.h"
 
 typedef int rcl_logging_ret_t;

--- a/rcl_logging_spdlog/include/rcl_logging_spdlog/logging_interface.h
+++ b/rcl_logging_spdlog/include/rcl_logging_spdlog/logging_interface.h
@@ -15,13 +15,12 @@
 #ifndef RCL_LOGGING_SPDLOG__LOGGING_INTERFACE_H_
 #define RCL_LOGGING_SPDLOG__LOGGING_INTERFACE_H_
 
+#include "rcl_logging_spdlog/visibility_control.h"
+#include "rcutils/allocator.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <rcutils/allocator.h>
-
-#include "rcl_logging_spdlog/visibility_control.h"
 
 typedef int rcl_logging_ret_t;
 


### PR DESCRIPTION
While running the ABI tool on the package the compilation of the headers displays a problem unable to found [`rcutils_allocator_t` in logging_interface.h](https://github.com/ros2/rcl_logging/compare/foxy...jrivero/missing_allocator_header_foxy?expand=1#diff-09665547ad7117bc6bfca31abb0cf87aR43). I think we are missing the include in the file. 