### PR TITLE
Used current_path() function from rcpputils

### DIFF
--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -28,8 +28,6 @@
 #include "gtest/gtest.h"
 #include "rcl_logging_interface/rcl_logging_interface.h"
 
-namespace fs = rcpputils::fs;
-
 const int logger_levels[] =
 {
   RCUTILS_LOG_SEVERITY_UNSET,
@@ -86,25 +84,25 @@ TEST_F(LoggingTest, init_failure)
   rcutils_reset_error();
 
   // Force failure to create directories
-  fs::path fake_home = rcpputils::fs::current_path() / "fake_home_dir";
-  ASSERT_TRUE(fs::create_directories(fake_home));
+  rcpputils::fs::path fake_home = rcpputils::fs::current_path() / "fake_home_dir";
+  ASSERT_TRUE(rcpputils::fs::create_directories(fake_home));
   ASSERT_EQ(true, rcutils_set_env("HOME", fake_home.string().c_str()));
 
   // ...fail to create .ros dir
-  fs::path ros_dir = fake_home / ".ros";
+  rcpputils::fs::path ros_dir = fake_home / ".ros";
   std::fstream(ros_dir.string(), std::ios_base::out).close();
   EXPECT_EQ(RCL_LOGGING_RET_ERROR, rcl_logging_external_initialize(nullptr, allocator));
-  ASSERT_TRUE(fs::remove(ros_dir));
+  ASSERT_TRUE(rcpputils::fs::remove(ros_dir));
 
   // ...fail to create .ros/log dir
-  ASSERT_TRUE(fs::create_directories(ros_dir));
-  fs::path ros_log_dir = ros_dir / "log";
+  ASSERT_TRUE(rcpputils::fs::create_directories(ros_dir));
+  rcpputils::fs::path ros_log_dir = ros_dir / "log";
   std::fstream(ros_log_dir.string(), std::ios_base::out).close();
   EXPECT_EQ(RCL_LOGGING_RET_ERROR, rcl_logging_external_initialize(nullptr, allocator));
-  ASSERT_TRUE(fs::remove(ros_log_dir));
-  ASSERT_TRUE(fs::remove(ros_dir));
+  ASSERT_TRUE(rcpputils::fs::remove(ros_log_dir));
+  ASSERT_TRUE(rcpputils::fs::remove(ros_dir));
 
-  ASSERT_TRUE(fs::remove(fake_home));
+  ASSERT_TRUE(rcpputils::fs::remove(fake_home));
 }
 
 TEST_F(LoggingTest, full_cycle)

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -63,27 +63,6 @@ private:
   const std::string value_;
 };
 
-// TODO(cottsay): Remove when ros2/rcpputils#63 is resolved
-static fs::path current_path()
-{
-#ifdef _WIN32
-#ifdef UNICODE
-#error "rcpputils::fs does not support Unicode paths"
-#endif
-  char cwd[MAX_PATH];
-  if (nullptr == _getcwd(cwd, MAX_PATH)) {
-#else
-  char cwd[PATH_MAX];
-  if (nullptr == getcwd(cwd, PATH_MAX)) {
-#endif
-    std::error_code ec{errno, std::system_category()};
-    errno = 0;
-    throw std::system_error{ec, "cannot get current working directory"};
-  }
-
-  return fs::path(cwd);
-}
-
 TEST_F(LoggingTest, init_invalid)
 {
   // Config files are not supported by spdlog
@@ -107,7 +86,7 @@ TEST_F(LoggingTest, init_failure)
   rcutils_reset_error();
 
   // Force failure to create directories
-  fs::path fake_home = current_path() / "fake_home_dir";
+  fs::path fake_home = rcpputils::fs::current_path() / "fake_home_dir";
   ASSERT_TRUE(fs::create_directories(fake_home));
   ASSERT_EQ(true, rcutils_set_env("HOME", fake_home.string().c_str()));
 


### PR DESCRIPTION
Removed TODO 

Compiling up-to `rcl_logging_spdlog` and testing `rcl_logging_spdlog` becuse this change only affect the spdlog test.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12339)](http://ci.ros2.org/job/ci_linux/12339/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7308)](http://ci.ros2.org/job/ci_linux-aarch64/7308/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10052)](http://ci.ros2.org/job/ci_osx/10052/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12248)](http://ci.ros2.org/job/ci_windows/12248/)


Signed-off-by: ahcorde <ahcorde@gmail.com>