### PR TITLE
[rcl_logging_spdlog] Add warnings

### DIFF
--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -20,6 +20,12 @@ find_package(spdlog REQUIRED)
 if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+  add_compile_options(
+    -Wformat=2 -Wconversion -Woverloaded-virtual -Wshadow
+    -Wnon-virtual-dtor -Wold-style-cast -Wcast-qual
+  )
+endif()
 
 add_library(${PROJECT_NAME} src/rcl_logging_spdlog.cpp)
 target_link_libraries(${PROJECT_NAME} spdlog::spdlog)

--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(spdlog REQUIRED)
 if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_ID MATCHES "Clang")
   add_compile_options(
     -Wformat=2 -Wconversion -Woverloaded-virtual -Wshadow
     -Wnon-virtual-dtor -Wold-style-cast -Wcast-qual

--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(spdlog REQUIRED)
 if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(
     -Wformat=2 -Wconversion -Woverloaded-virtual -Wshadow
     -Wnon-virtual-dtor -Wold-style-cast -Wcast-qual


### PR DESCRIPTION
This PR enables `-Wformat=2`, `-Wconversion`, `-Woverloaded-virtual`, `-Wshadow`, `-Wnon-virtual-dtor`, `-Wold-style-cast`, and `-Wcast-qual` in `rcl_logging_spdlog`. No source code was modified to enable these warnings.

Relies on `googletest` being v1.10.0 (https://github.com/ament/googletest/pull/8).