### PR TITLE
Make internal dependencies private

### DIFF
--- a/rcl_logging_noop/CMakeLists.txt
+++ b/rcl_logging_noop/CMakeLists.txt
@@ -25,10 +25,10 @@ set(${PROJECT_NAME}_sources
 
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})
 
-ament_target_dependencies(${PROJECT_NAME}
-  rcl_logging_interface
-  rcutils
-)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  rcutils::rcutils)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rcl_logging_interface::rcl_logging_interface)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_LOGGING_INTERFACE_BUILDING_DLL")
 
@@ -43,7 +43,8 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   RUNTIME DESTINATION bin)
 
 
-ament_export_dependencies(ament_cmake rcl_logging_interface rcutils)
+# Export rcl_logging_interface to give downstream packages access to it's headers
+ament_export_dependencies(rcl_logging_interface)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 ament_package()

--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -23,14 +23,12 @@ if(NOT WIN32)
 endif()
 
 add_library(${PROJECT_NAME} src/rcl_logging_spdlog.cpp)
-target_link_libraries(${PROJECT_NAME} spdlog::spdlog)
-
-ament_target_dependencies(${PROJECT_NAME}
-  rcl_logging_interface
-  rcpputils
-  rcutils
-  spdlog
-)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  rcpputils::rcpputils
+  rcutils::rcutils
+  spdlog::spdlog)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rcl_logging_interface::rcl_logging_interface)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_LOGGING_INTERFACE_BUILDING_DLL")
 
@@ -61,7 +59,8 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-ament_export_dependencies(ament_cmake rcl_logging_interface rcutils spdlog_vendor spdlog)
+# Export rcl_logging_interface to give downstream packages access to it's headers
+ament_export_dependencies(rcl_logging_interface)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
`rcpputils`, `rcutils`, and `spdlog` don't need to be exposed to downstream users of this package at their build time because these dependencies are only used internally.

I think `rcl_logging_interface` should still be exposed because this package only appears to be useful if one has those headers, but that won't affect how this is currently used downstream because `rcl` [already depends on both](https://github.com/ros2/rcl/blob/e9c87e279bf7509c940b87fd4d6c5dff301bc735/rcl/package.xml#L19-L20) and has [custom CMake logic to `find_package()` it](https://github.com/ros2/rcl/blob/e9c87e279bf7509c940b87fd4d6c5dff301bc735/rcl/CMakeLists.txt#L18).

Fixes #58 

Uses `target_link_libraries()` because all of its dependencies are using targets already ament/ament_cmake#292