### PR TITLE
Make sure to check return value from external_initialize.

### DIFF
--- a/rcl_logging_spdlog/test/benchmark/benchmark_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/benchmark/benchmark_logging_interface.cpp
@@ -88,6 +88,9 @@ BENCHMARK_F(PerformanceTest, logging_reinitialize)(benchmark::State & st)
 {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   rcl_logging_ret_t ret = rcl_logging_external_initialize(nullptr, allocator);
+  if (ret != RCL_LOGGING_RET_OK) {
+    st.SkipWithError(rcutils_get_error_string().str);
+  }
 
   reset_heap_counters();
 


### PR DESCRIPTION
Pointed out by clang static analysis as a dead store.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>