### PR TITLE
Include what you use

### DIFF
--- a/rcl_logging_spdlog/test/fixtures.hpp
+++ b/rcl_logging_spdlog/test/fixtures.hpp
@@ -23,6 +23,9 @@
 #include <rcutils/types/string_array.h>
 
 #include <limits.h>
+#ifdef _WIN32
+# include <windows.h>  // MAX_PATH
+#endif
 #include <string>
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
MAX_PATH is defined in `windows.h` and after https://github.com/ros2/rcpputils/pull/118 is not being automatically included by `rcpputils/filesystem_helper.hpp` anymore.