### PR TITLE
Update includes after rcutils/get_env.h deprecation

### DIFF
--- a/rcl_logging_interface/src/logging_dir.c
+++ b/rcl_logging_interface/src/logging_dir.c
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include <rcutils/allocator.h>
+#include <rcutils/env.h>
 #include <rcutils/error_handling.h>
 #include <rcutils/filesystem.h>
 #include <rcutils/format_string.h>
-#include <rcutils/get_env.h>
 #include <rcutils/strdup.h>
 
 #include "rcl_logging_interface/rcl_logging_interface.h"

--- a/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
+++ b/rcl_logging_log4cxx/src/rcl_logging_log4cxx/rcl_logging_log4cxx.cpp
@@ -15,7 +15,6 @@
 #include <rcl_logging_interface/rcl_logging_interface.h>
 
 #include <rcutils/allocator.h>
-#include <rcutils/get_env.h>
 #include <rcutils/logging.h>
 #include <rcutils/process.h>
 #include <rcutils/time.h>

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -14,7 +14,6 @@
 
 #include <rcpputils/filesystem_helper.hpp>
 #include <rcutils/allocator.h>
-#include <rcutils/get_env.h>
 #include <rcutils/logging.h>
 #include <rcutils/process.h>
 #include <rcutils/snprintf.h>

--- a/rcl_logging_spdlog/test/fixtures.hpp
+++ b/rcl_logging_spdlog/test/fixtures.hpp
@@ -17,8 +17,8 @@
 
 #include <rcpputils/filesystem_helper.hpp>
 #include <rcutils/allocator.h>
+#include <rcutils/env.h>
 #include <rcutils/error_handling.h>
-#include <rcutils/get_env.h>
 #include <rcutils/process.h>
 #include <rcutils/types/string_array.h>
 


### PR DESCRIPTION
https://github.com/ros2/rcutils/pull/340 deprecates `rcutils/get_env.h`. This PR doesn't need to wait until the `rcutils` PR is merged, though.

Note that in some cases I simply removed the `#include` since nothing from that header was actually used.