### PR TITLE
macOS build fix

### DIFF
--- a/rcl_logging_log4cxx/CMakeLists.txt
+++ b/rcl_logging_log4cxx/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_C_STANDARD)
 endif()
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 find_package(ament_cmake_ros REQUIRED)


### PR DESCRIPTION
The newest version of `log4cxx` on macOS is now built with C++17 on homebrew (the expected way to install the package, based on the ROS2 installation guide). C++17 adds support for `shared_mutex`, so `log4cxx` defaults to using `shared_mutex` in `std` instead of `boost`. C++14, however, doesn't have `shared_mutex`, so building `rcl_logging_log4cxx` on macOS with the latest packages now fails because it uses C++14. The easiest way to fix this is to switch this package to build on C++17, which is what I've done here. 

If you all have any other solutions to this issue feel free to propose them, but this is the simplest one I could come up with, and is imperative for all macOS ROS2 users building from source.