### PR TITLE
Fix renamed `rcpputils` header

### DIFF
--- a/rcl_logging_interface/test/test_get_logging_directory.cpp
+++ b/rcl_logging_interface/test/test_get_logging_directory.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <rcpputils/filesystem_helper.hpp>
-#include <rcpputils/get_env.hpp>
+#include <rcpputils/env.hpp>
 #include <rcutils/allocator.h>
 #include <rcutils/env.h>
 #include <rcutils/error_handling.h>

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <rcpputils/filesystem_helper.hpp>
-#include <rcpputils/get_env.hpp>
+#include <rcpputils/env.hpp>
 #include <rcutils/allocator.h>
 #include <rcutils/env.h>
 #include <rcutils/error_handling.h>


### PR DESCRIPTION
`rcpputils/get_env.hpp` is renamed to `rcpputils/env.hpp` as part of https://github.com/ros2/rcpputils/pull/150, so the corresponding includes have been fixed in this PR.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>