### PR TITLE
Install includes to include/${PROJECT_NAME}

### DIFF
--- a/rcl_logging_interface/CMakeLists.txt
+++ b/rcl_logging_interface/CMakeLists.txt
@@ -24,21 +24,25 @@ set(${PROJECT_NAME}_sources
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 ament_target_dependencies(${PROJECT_NAME} rcutils)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_LOGGING_INTERFACE_BUILDING_DLL")
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+
+# Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
+
 ament_export_dependencies(rcutils)
 
 if(BUILD_TESTING)
@@ -50,7 +54,6 @@ if(BUILD_TESTING)
   ament_add_gtest(test_get_logging_directory test/test_get_logging_directory.cpp)
   if(TARGET test_get_logging_directory)
     target_link_libraries(test_get_logging_directory ${PROJECT_NAME})
-    target_include_directories(test_get_logging_directory PRIVATE include)
     ament_target_dependencies(test_get_logging_directory rcutils rcpputils)
   endif()
 endif()


### PR DESCRIPTION
Part of ros2/ros2#1150 - This eliminates issues with the include directory search order when overriding these packages by installing their includes to `include/${PROJECT_NAME}`