### PR TITLE
Export spdlog dependency for rcl_logging_spdlog

### DIFF
--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -66,7 +66,7 @@ if(BUILD_TESTING)
 endif()
 
 # Export rcl_logging_interface to give downstream packages access to it's headers
-ament_export_dependencies(rcl_logging_interface)
+ament_export_dependencies(rcl_logging_interface spdlog)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
## Information

OS: Apertis 2022 (Debian bullseye based)
ROS Version: Galactic
rcl_logging version: [2.1.4](https://github.com/ros2/rcl_logging/commit/d43160b7a3ea4dfebe8d11cfb36c21a4da198ea3)
GCC: aarch64-linux-gnu-g++ (Apertis 10.2.1-6+apertis2+apertispro0bv2022dev3b1) 10.2.1 20210110
Arch: aarch64

## Description
When cross-building for our project, `rclcpp_components` and other `rclcpp` packages fails to link to spdlog, saying: `spdlog.so.1 not found` while available in the workspace's lib folder (which is in the `CMAKE_FIND_ROOT_PATH`). 

Explicitly adding spdlog as a dependency of `rcl_logging_spdlog` fixes the issue.

```cpp 
ament_export_dependencies(rcl_logging_interface spdlog)
```

Note: The build works fine without this when building natively on the host (x86_64). 
Note2: This fix is based on the galactic branch