### PR TITLE
ament_export_dependencies any package with targets we linked against

### DIFF
--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -65,8 +65,11 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-# Export rcl_logging_interface to give downstream packages access to it's headers
 ament_export_dependencies(rcl_logging_interface)
+ament_export_dependencies(rcpputils)
+ament_export_dependencies(rcutils)
+ament_export_dependencies(spdlog_vendor)
+ament_export_dependencies(spdlog)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
Resolves #82 

When building static libraries [CMake will link PRIVATE targets downstream as if they were PUBLIC](https://cmake.org/pipermail/cmake/2016-May/063400.html). This calls `ament_export_dependencies` on all packages providing targets that are linked against so downstream packages have those targets available too.