### PR TITLE
Disable cppcheck for rcl_logging_spdlog.

### DIFF
--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -45,12 +45,15 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # cppcheck 1.90 doesn't understand some of the syntax in spdlog's bundled fmt
+  # code.  Since we already have cppcheck disabled on Linux, just disable it
+  # completely for this package.
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_cppcheck
+  )
   ament_lint_auto_find_test_dependencies()
 
   find_package(performance_test_fixture REQUIRED)
-  # Give cppcheck hints about macro definitions coming from outside this package
-  get_target_property(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS
-    performance_test_fixture::performance_test_fixture INTERFACE_INCLUDE_DIRECTORIES)
 
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_logging_interface test/test_logging_interface.cpp)


### PR DESCRIPTION
The comment explains why.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>