### PR TITLE
change flushing behavior for spdlog log files, and add env var to use old style (no explicit flushing)

### DIFF
--- a/rcl_logging_spdlog/CMakeLists.txt
+++ b/rcl_logging_spdlog/CMakeLists.txt
@@ -56,7 +56,7 @@ if(BUILD_TESTING)
   find_package(performance_test_fixture REQUIRED)
 
   find_package(ament_cmake_gtest REQUIRED)
-  ament_add_gtest(test_logging_interface test/test_logging_interface.cpp)
+  ament_add_gmock(test_logging_interface test/test_logging_interface.cpp)
   if(TARGET test_logging_interface)
     target_link_libraries(test_logging_interface ${PROJECT_NAME})
     target_compile_definitions(test_logging_interface PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -34,7 +34,7 @@
 #include "rcl_logging_interface/rcl_logging_interface.h"
 
 static std::mutex g_logger_mutex;
-static std::unique_ptr<spdlog::logger> g_root_logger = nullptr;
+static std::shared_ptr<spdlog::logger> g_root_logger = nullptr;
 
 static spdlog::level::level_enum map_external_log_level_to_library_level(int external_level)
 {
@@ -186,6 +186,8 @@ rcl_logging_ret_t rcl_logging_external_initialize(
       // the old behavior is to not configure the sink at all, so do nothing
     }
 
+    spdlog::register_logger(g_root_logger);
+
     g_root_logger->set_pattern("%v");
   }
 
@@ -194,6 +196,7 @@ rcl_logging_ret_t rcl_logging_external_initialize(
 
 rcl_logging_ret_t rcl_logging_external_shutdown()
 {
+  spdlog::drop("root");
   g_root_logger = nullptr;
   return RCL_LOGGING_RET_OK;
 }

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cerrno>
+#include <chrono>
 #include <cinttypes>
 #include <memory>
 #include <mutex>
@@ -20,6 +21,7 @@
 #include <utility>
 
 #include "rcpputils/filesystem_helper.hpp"
+#include "rcpputils/env.hpp"
 #include "rcutils/allocator.h"
 #include "rcutils/logging.h"
 #include "rcutils/process.h"
@@ -53,6 +55,42 @@ static spdlog::level::level_enum map_external_log_level_to_library_level(int ext
   return level;
 }
 
+namespace
+{
+
+RCL_LOGGING_INTERFACE_LOCAL
+bool
+get_should_use_old_flushing_behavior()
+{
+  const char * env_var_name = "RCL_LOGGING_SPDLOG_EXPERIMENTAL_OLD_FLUSHING_BEHAVIOR";
+
+  try {
+    std::string env_var_value = rcpputils::get_env_var(env_var_name);
+
+    if (env_var_value.empty()) {
+      // not set
+      return false;
+    }
+    if ("0" == env_var_value) {
+      // explicitly false
+      return false;
+    }
+    if ("1" == env_var_value) {
+      // explicitly true
+      return true;
+    }
+
+    // unknown value
+    throw std::runtime_error("unrecognized value: " + env_var_value);
+  } catch (const std::runtime_error & error) {
+    throw std::runtime_error(
+            std::string("failed to get env var '") + env_var_name + "': " + error.what()
+    );
+  }
+}
+
+}  // namespace
+
 rcl_logging_ret_t rcl_logging_external_initialize(
   const char * config_file,
   rcutils_allocator_t allocator)
@@ -72,6 +110,16 @@ rcl_logging_ret_t rcl_logging_external_initialize(
       "spdlog logging backend doesn't currently support external configuration");
     return RCL_LOGGING_RET_ERROR;
   } else {
+    // check RCL_LOGGING_SPDLOG_EXPERIMENTAL_OLD_FLUSHING_BEHAVIOR to see if we
+    // should change log file flushing behavior
+    bool should_use_old_flushing_behavior = false;
+    try {
+      should_use_old_flushing_behavior = ::get_should_use_old_flushing_behavior();
+    } catch (const std::runtime_error & error) {
+      RCUTILS_SET_ERROR_MSG(error.what());
+      return RCL_LOGGING_RET_ERROR;
+    }
+
     // To be compatible with ROS 1, we construct a default filename of
     // the form ~/.ros/log/<exe>_<pid>_<milliseconds-since-epoch>.log
 
@@ -128,6 +176,15 @@ rcl_logging_ret_t rcl_logging_external_initialize(
 
     auto sink = std::make_unique<spdlog::sinks::basic_file_sink_mt>(name_buffer, false);
     g_root_logger = std::make_unique<spdlog::logger>("root", std::move(sink));
+    if (!should_use_old_flushing_behavior) {
+      // in this case we should do the new thing (until config files are supported)
+      // which is to configure the logger to flush periodically and on
+      // error level messages
+      spdlog::flush_every(std::chrono::seconds(5));
+      g_root_logger->flush_on(spdlog::level::err);
+    } else {
+      // the old behavior is to not configure the sink at all, so do nothing
+    }
 
     g_root_logger->set_pattern("%v");
   }

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -175,7 +175,7 @@ rcl_logging_ret_t rcl_logging_external_initialize(
     }
 
     auto sink = std::make_unique<spdlog::sinks::basic_file_sink_mt>(name_buffer, false);
-    g_root_logger = std::make_unique<spdlog::logger>("root", std::move(sink));
+    g_root_logger = std::make_shared<spdlog::logger>("root", std::move(sink));
     if (!should_use_old_flushing_behavior) {
       // in this case we should do the new thing (until config files are supported)
       // which is to configure the logger to flush periodically and on


### PR DESCRIPTION
While working on a project we noticed some applications have missing log messages or no log file at all when it crashes. This isn't a good experience for users when debugging, so this pr changes the flushing behavior of spdlog to flush every five seconds as well as anytime the error log level is used.

A new environment variable is introduced to allow users to opt-out of this back to the old behavior (no explicit configuration) and is meant to be temporary until we support full config files (planned work).

The new env var is called `RCL_LOGGING_SPDLOG_EXPERIMENTAL_OLD_FLUSHING_BEHAVIOR` and setting it to `1` will get you the old behavior. I'm very open to other names, but the "EXPERIMENTAL" is in there in part to indicate we would like to remove this in the future in favor of the config files, i.e. this is experimental and you cannot rely on it in the next version of ROS.