### PR TITLE
Mark the benchmark _ as unused.

### DIFF
--- a/rcl_logging_spdlog/test/benchmark/benchmark_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/benchmark/benchmark_logging_interface.cpp
@@ -15,6 +15,7 @@
 
 #include <rcutils/allocator.h>
 #include <rcutils/logging.h>
+#include <rcutils/macros.h>
 
 #include <rcl_logging_interface/rcl_logging_interface.h>
 
@@ -72,6 +73,7 @@ BENCHMARK_F(LoggingBenchmarkPerformance, log_level_hit)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     rcl_logging_external_log(RCUTILS_LOG_SEVERITY_INFO, nullptr, data.c_str());
   }
 }
@@ -80,6 +82,7 @@ BENCHMARK_F(LoggingBenchmarkPerformance, log_level_miss)(benchmark::State & st)
 {
   setLogLevel(RCUTILS_LOG_SEVERITY_INFO, st);
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     rcl_logging_external_log(RCUTILS_LOG_SEVERITY_DEBUG, nullptr, data.c_str());
   }
 }
@@ -95,6 +98,7 @@ BENCHMARK_F(PerformanceTest, logging_reinitialize)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     ret = rcl_logging_external_initialize(nullptr, allocator);
     if (ret != RCL_LOGGING_RET_OK) {
       st.SkipWithError(rcutils_get_error_string().str);
@@ -111,6 +115,7 @@ BENCHMARK_F(PerformanceTest, logging_initialize_shutdown)(benchmark::State & st)
 {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     rcl_logging_ret_t ret = rcl_logging_external_initialize(nullptr, allocator);
     if (ret != RCL_LOGGING_RET_OK) {
       st.SkipWithError(rcutils_get_error_string().str);


### PR DESCRIPTION
This just makes clang happier.