### PR TITLE
Improve error message handling for spdlog

### DIFF
--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -133,7 +133,7 @@ rcl_logging_ret_t rcl_logging_external_initialize(
     if (RCL_LOGGING_RET_OK != dir_ret) {
       // We couldn't get the log directory, so get out of here without setting up
       // logging.
-      RCUTILS_SET_ERROR_MSG("Failed to get logging directory");
+      RCUTILS_SET_ERROR_MSG_AND_APPEND_PREV_ERROR("Failed to get logging directory");
       return dir_ret;
     }
     RCPPUTILS_SCOPE_EXIT(

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -68,14 +68,17 @@ TEST_F(LoggingTest, init_invalid)
   EXPECT_EQ(
     RCL_LOGGING_RET_ERROR,
     rcl_logging_external_initialize(nullptr, "anything", allocator));
+  EXPECT_TRUE(rcutils_error_is_set());
   rcutils_reset_error();
   EXPECT_EQ(
     RCL_LOGGING_RET_ERROR,
     rcl_logging_external_initialize("anything", nullptr, bad_allocator));
+  EXPECT_TRUE(rcutils_error_is_set());
   rcutils_reset_error();
   EXPECT_EQ(
     RCL_LOGGING_RET_ERROR,
     rcl_logging_external_initialize(nullptr, nullptr, invalid_allocator));
+  EXPECT_TRUE(rcutils_error_is_set());
   rcutils_reset_error();
 }
 
@@ -88,6 +91,7 @@ TEST_F(LoggingTest, init_failure)
   ASSERT_EQ(true, rcutils_set_env("HOME", nullptr));
   ASSERT_EQ(true, rcutils_set_env("USERPROFILE", nullptr));
   EXPECT_EQ(RCL_LOGGING_RET_ERROR, rcl_logging_external_initialize(nullptr, nullptr, allocator));
+  EXPECT_TRUE(rcutils_error_is_set());
   rcutils_reset_error();
 
   // Force failure to create directories
@@ -99,6 +103,8 @@ TEST_F(LoggingTest, init_failure)
   std::filesystem::path ros_dir = fake_home / ".ros";
   std::fstream(ros_dir.string(), std::ios_base::out).close();
   EXPECT_EQ(RCL_LOGGING_RET_ERROR, rcl_logging_external_initialize(nullptr, nullptr, allocator));
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
   ASSERT_TRUE(std::filesystem::remove(ros_dir));
 
   // ...fail to create .ros/log dir
@@ -106,6 +112,8 @@ TEST_F(LoggingTest, init_failure)
   std::filesystem::path ros_log_dir = ros_dir / "log";
   std::fstream(ros_log_dir.string(), std::ios_base::out).close();
   EXPECT_EQ(RCL_LOGGING_RET_ERROR, rcl_logging_external_initialize(nullptr, nullptr, allocator));
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
   ASSERT_TRUE(std::filesystem::remove(ros_log_dir));
   ASSERT_TRUE(std::filesystem::remove(ros_dir));
 


### PR DESCRIPTION
Kind of relates to https://github.com/ros2/rcutils/issues/269

1. Modify tests to _expect_ the error message to be set when it should be set and then reset it
2. In `rcl_logging_spdlog`'s `rcl_logging_external_initialize()`: in case of `rcl_logging_get_logging_directory()` failure, append error message instead of overwriting it without resetting it (and thus generating a "This error state is being overwritten" warning)

This results in `rcl_logging_spdlog/test_test_logging_interface.cpp` not generating any "This error state is being overwritten" warnings.