### PR TITLE
Re-order rcl_logging_interface include

### DIFF
--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -19,6 +19,7 @@
 
 #include "gmock/gmock.h"
 
+#include "rcl_logging_interface/rcl_logging_interface.h"
 #include "rcpputils/env.hpp"
 #include "rcutils/allocator.h"
 #include "rcutils/env.h"
@@ -27,7 +28,6 @@
 #include "rcutils/testing/fault_injection.h"
 
 #include "fixtures.hpp"
-#include "rcl_logging_interface/rcl_logging_interface.h"
 
 const int logger_levels[] =
 {


### PR DESCRIPTION
We're not very strict about includes, but I noticed a slight divergence as a result of https://github.com/ros2/rcl_logging/pull/41