### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@ This repository contains several packages which are all related to the ROS loggi
 
 ## Packages
 
-- rcl_logging_spdlog
-- rcl_logging_log4cxx
+- rcl_logging_interface
 - rcl_logging_noop
+- rcl_logging_spdlog


### PR DESCRIPTION
Update list of packages: `rcl_logging_interface` was added in #41 and `rcl_logging_log4cxx` was removed in #78.