### PR TITLE
Use (void) in declaration of param-less function

### DIFF
--- a/rcl_logging_interface/include/rcl_logging_interface/rcl_logging_interface.h
+++ b/rcl_logging_interface/include/rcl_logging_interface/rcl_logging_interface.h
@@ -69,7 +69,7 @@ rcl_logging_external_initialize(
 RCL_LOGGING_INTERFACE_PUBLIC
 RCUTILS_WARN_UNUSED
 rcl_logging_ret_t
-rcl_logging_external_shutdown();
+rcl_logging_external_shutdown(void);
 
 /// Log a message.
 /**


### PR DESCRIPTION
Some more picky linters report it, but in any case we do this in most (if not all) of ROS 2's C `.h` files.