### PR TITLE
Check allocator validity in some rcl_logging functions

### DIFF
--- a/rcl_logging_interface/src/logging_dir.c
+++ b/rcl_logging_interface/src/logging_dir.c
@@ -28,6 +28,7 @@ rcl_logging_get_logging_directory(rcutils_allocator_t allocator, char ** directo
     RCUTILS_SET_ERROR_MSG("directory argument must not be null");
     return RCL_LOGGING_RET_INVALID_ARGUMENT;
   }
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCL_LOGGING_RET_INVALID_ARGUMENT);
   if (NULL != *directory) {
     RCUTILS_SET_ERROR_MSG("directory argument must point to null");
     return RCL_LOGGING_RET_INVALID_ARGUMENT;

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -100,6 +100,8 @@ rcl_logging_ret_t rcl_logging_external_initialize(
   const char * config_file,
   rcutils_allocator_t allocator)
 {
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCL_LOGGING_RET_INVALID_ARGUMENT);
+
   std::lock_guard<std::mutex> lk(g_logger_mutex);
   // It is possible for this to get called more than once in a process (some of
   // the tests do this implicitly by calling rclcpp::init more than once).

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -74,7 +74,7 @@ TEST_F(LoggingTest, init_invalid)
     rcl_logging_external_initialize("anything", nullptr, bad_allocator));
   rcutils_reset_error();
   EXPECT_EQ(
-    RCL_LOGGING_RET_ERROR,
+    RCL_LOGGING_RET_INVALID_ARGUMENT,
     rcl_logging_external_initialize(nullptr, nullptr, invalid_allocator));
   rcutils_reset_error();
 }


### PR DESCRIPTION
If the allocator is zero-initialized, it may cause a segfault when it is used later in the function. Right now, we're relying on other `rcutils_*` functions which use the allocator to fail before we attempt to use it directly, but just because the allocator is passed to these functions doesn't always mean that it is used, especially when the program flow can change based on things like environment variables.