### PR TITLE
Cleanup overwritten warning messages on error.

### DIFF
--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -134,8 +134,7 @@ rcl_logging_ret_t rcl_logging_external_initialize(
     rcl_logging_ret_t dir_ret = rcl_logging_get_logging_directory(allocator, &logdir);
     if (RCL_LOGGING_RET_OK != dir_ret) {
       // We couldn't get the log directory, so exit without setting up logging.
-      rcutils_reset_error();
-      RCUTILS_SET_ERROR_MSG("Failed to get logging directory");
+      RCUTILS_SET_ERROR_MSG_AND_APPEND_PREV_ERROR("Failed to get logging directory");
       return dir_ret;
     }
     RCPPUTILS_SCOPE_EXIT(

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -133,8 +133,8 @@ rcl_logging_ret_t rcl_logging_external_initialize(
     char * logdir = nullptr;
     rcl_logging_ret_t dir_ret = rcl_logging_get_logging_directory(allocator, &logdir);
     if (RCL_LOGGING_RET_OK != dir_ret) {
-      // We couldn't get the log directory, so get out of here without setting up
-      // logging.
+      // We couldn't get the log directory, so exit without setting up logging.
+      rcutils_reset_error();
       RCUTILS_SET_ERROR_MSG("Failed to get logging directory");
       return dir_ret;
     }

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -218,6 +218,7 @@ TEST_F(AllocatorTest, init_failure)
   std::filesystem::path ros_dir = fake_home / ".ros";
   std::fstream(ros_dir.string(), std::ios_base::out).close();
   EXPECT_EQ(RCL_LOGGING_RET_ERROR, rcl_logging_external_initialize(nullptr, nullptr, allocator));
+  rcutils_reset_error();
   ASSERT_TRUE(std::filesystem::remove(ros_dir));
 
   // ...fail to create .ros/log dir
@@ -225,6 +226,7 @@ TEST_F(AllocatorTest, init_failure)
   std::filesystem::path ros_log_dir = ros_dir / "log";
   std::fstream(ros_log_dir.string(), std::ios_base::out).close();
   EXPECT_EQ(RCL_LOGGING_RET_ERROR, rcl_logging_external_initialize(nullptr, nullptr, allocator));
+  rcutils_reset_error();
   ASSERT_TRUE(std::filesystem::remove(ros_log_dir));
   ASSERT_TRUE(std::filesystem::remove(ros_dir));
 


### PR DESCRIPTION
This just makes the output look nicer in error paths.