### PR TITLE
Cleanup rcl_logging_noop dependencies.

### DIFF
--- a/rcl_logging_noop/CMakeLists.txt
+++ b/rcl_logging_noop/CMakeLists.txt
@@ -23,8 +23,7 @@ endif()
 add_library(${PROJECT_NAME} src/rcl_logging_noop.cpp)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  rcutils::rcutils)
-target_link_libraries(${PROJECT_NAME} PUBLIC
+  rcutils::rcutils
   rcl_logging_interface::rcl_logging_interface)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_LOGGING_INTERFACE_BUILDING_DLL")

--- a/rcl_logging_noop/Doxyfile
+++ b/rcl_logging_noop/Doxyfile
@@ -4,11 +4,7 @@ PROJECT_NAME           = "rcl_logging_noop"
 PROJECT_NUMBER         = master
 PROJECT_BRIEF          = "A library implementation of the rcl_logging interface that does nothing."
 
-# Use these lines to include the generated logging_macro.h (update install path if needed)
-#INPUT                  = README.md ../../../install_isolated/rcutils/include
-#STRIP_FROM_PATH        = /Users/william/ros2_ws/install_isolated/rcutils/include
-# Otherwise just generate for the local (non-generated header files)
-INPUT                  = README.md ./include
+INPUT                  = README.md
 USE_MDFILE_AS_MAINPAGE = README.md
 RECURSIVE              = YES
 OUTPUT_DIRECTORY       = doc_output

--- a/rcl_logging_noop/package.xml
+++ b/rcl_logging_noop/package.xml
@@ -14,16 +14,15 @@
   <author email="william@osrfoundation.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <buildtool_depend>python3-empy</buildtool_depend>
 
-  <depend>rcl_logging_interface</depend>
-  <depend>rcutils</depend>
+  <build_depend>rcl_logging_interface</build_depend>
+  <build_depend>rcutils</build_depend>
 
-  <test_depend>ament_cmake_gmock</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
+  <exec_depend>rcl_logging_interface</exec_depend>
+  <exec_depend>rcutils</exec_depend>
+
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>launch_testing</test_depend>
 
   <member_of_group>rcl_logging_packages</member_of_group>
 


### PR DESCRIPTION
## Description

It shouldn't build_export_depend anything (as nothing downstream should link against it), and all of its dependencies can be private.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

N/A