### PR TITLE
feat: add env variable to configure flushing interval

### DIFF
--- a/rcl_logging_spdlog/README.md
+++ b/rcl_logging_spdlog/README.md
@@ -8,6 +8,22 @@ Package supporting an implementation of logging functionality using `spdlog`.
  - set the logger level
  - shutdown
 
+## Environment Variables
+
+### `RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS`
+
+Controls the periodic flush interval for log files. By default, logs are flushed every 5 seconds and immediately on error-level messages.
+
+| Value | Behavior |
+|-------|----------|
+| Not set | Default: flush every 5 seconds + on error |
+| `0` | Immediate flush on every log message (unbuffered) |
+| `N` (positive integer) | Flush every N seconds + on error |
+
+### `RCL_LOGGING_SPDLOG_EXPERIMENTAL_OLD_FLUSHING_BEHAVIOR`
+
+When set to `1`, disables all automatic flushing configuration (legacy behavior). This takes precedence over `RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS`.
+
 ## Quality Declaration
 
 This package claims to be in the **Quality Level 1** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -37,6 +37,8 @@
 
 #include "rcl_logging_interface/rcl_logging_interface.h"
 
+#define RCL_LOGGING_SPDLOG_FLUSH_DEFAULT_DURATION 5
+
 static std::mutex g_logger_mutex;
 static std::shared_ptr<spdlog::logger> g_root_logger = nullptr;
 
@@ -108,7 +110,7 @@ get_flush_period_seconds()
 
     if (env_var_value.empty()) {
       // not set, use default
-      return 5;
+      return RCL_LOGGING_SPDLOG_FLUSH_DEFAULT_DURATION;
     }
 
     // Parse the integer value
@@ -248,7 +250,7 @@ rcl_logging_ret_t rcl_logging_external_initialize(
       // in this case we should do the new thing (until config files are supported)
       // which is to configure the logger to flush periodically and on
       // error level messages
-      int flush_period_seconds = 5;  // default
+      int flush_period_seconds = RCL_LOGGING_SPDLOG_FLUSH_DEFAULT_DURATION;
       try {
         flush_period_seconds = ::get_flush_period_seconds();
       } catch (const std::runtime_error & error) {

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -113,18 +113,17 @@ get_flush_period_seconds()
       return RCL_LOGGING_SPDLOG_FLUSH_DEFAULT_DURATION;
     }
 
+    // Reject anything that isn't purely digits (no whitespace, signs, hex, etc.)
+    for (char c : env_var_value) {
+      if (!std::isdigit(static_cast<unsigned char>(c))) {
+        throw std::runtime_error(
+          std::string("invalid value for ") + env_var_name +
+          ": expected a non-negative integer, got '" + env_var_value + "'");
+      }
+    }
+
     // Parse the integer value
-    std::size_t pos = 0;
-    int value = std::stoi(env_var_value, &pos);
-
-    // Check if the entire string was consumed (no trailing garbage)
-    if (pos != env_var_value.length()) {
-      throw std::runtime_error("invalid value (trailing characters): " + env_var_value);
-    }
-
-    if (value < 0) {
-      throw std::runtime_error("invalid value (negative): " + env_var_value);
-    }
+    int value = std::stoi(env_var_value);
 
     if (get_should_use_old_flushing_behavior()) {
       throw std::runtime_error(

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -93,6 +93,55 @@ get_should_use_old_flushing_behavior()
   }
 }
 
+/// \brief Get the flush period in seconds from environment variable.
+/// \return The flush period in seconds. Returns 5 (default) if not set.
+///         Returns 0 for immediate flushing on every log.
+///         Throws std::runtime_error for invalid values.
+RCL_LOGGING_INTERFACE_LOCAL
+int
+get_flush_period_seconds()
+{
+  const char * env_var_name = "RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS";
+
+  try {
+    std::string env_var_value = rcpputils::get_env_var(env_var_name);
+
+    if (env_var_value.empty()) {
+      // not set, use default
+      return 5;
+    }
+
+    // Parse the integer value
+    std::size_t pos = 0;
+    int value = std::stoi(env_var_value, &pos);
+
+    // Check if the entire string was consumed (no trailing garbage)
+    if (pos != env_var_value.length()) {
+      throw std::runtime_error("invalid value (trailing characters): " + env_var_value);
+    }
+
+    if (value < 0) {
+      throw std::runtime_error("invalid value (negative): " + env_var_value);
+    }
+
+    return value;
+  } catch (const std::invalid_argument &) {
+    throw std::runtime_error(
+            std::string("failed to get env var '") + env_var_name +
+            "': value is not a valid integer"
+    );
+  } catch (const std::out_of_range &) {
+    throw std::runtime_error(
+            std::string("failed to get env var '") + env_var_name +
+            "': value is out of range"
+    );
+  } catch (const std::runtime_error & error) {
+    throw std::runtime_error(
+            std::string("failed to get env var '") + env_var_name + "': " + error.what()
+    );
+  }
+}
+
 }  // namespace
 
 rcl_logging_ret_t rcl_logging_external_initialize(
@@ -199,8 +248,22 @@ rcl_logging_ret_t rcl_logging_external_initialize(
       // in this case we should do the new thing (until config files are supported)
       // which is to configure the logger to flush periodically and on
       // error level messages
-      spdlog::flush_every(std::chrono::seconds(5));
-      g_root_logger->flush_on(spdlog::level::err);
+      int flush_period_seconds = 5;  // default
+      try {
+        flush_period_seconds = ::get_flush_period_seconds();
+      } catch (const std::runtime_error & error) {
+        RCUTILS_SET_ERROR_MSG(error.what());
+        g_root_logger = nullptr;
+        return RCL_LOGGING_RET_ERROR;
+      }
+
+      if (flush_period_seconds == 0) {
+        // Flush immediately on every log message (unbuffered mode)
+        g_root_logger->flush_on(spdlog::level::trace);
+      } else {
+        spdlog::flush_every(std::chrono::seconds(flush_period_seconds));
+        g_root_logger->flush_on(spdlog::level::err);
+      }
     } else {
       // the old behavior is to not configure the sink at all, so do nothing
     }

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -126,6 +126,12 @@ get_flush_period_seconds()
       throw std::runtime_error("invalid value (negative): " + env_var_value);
     }
 
+    if (get_should_use_old_flushing_behavior()) {
+      throw std::runtime_error(
+              "cannot set flush period when old flushing behavior is enabled"
+      );
+    }
+
     return value;
   } catch (const std::invalid_argument &) {
     throw std::runtime_error(

--- a/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
+++ b/rcl_logging_spdlog/src/rcl_logging_spdlog.cpp
@@ -113,17 +113,32 @@ get_flush_period_seconds()
       return RCL_LOGGING_SPDLOG_FLUSH_DEFAULT_DURATION;
     }
 
-    // Reject anything that isn't purely digits (no whitespace, signs, hex, etc.)
-    for (char c : env_var_value) {
-      if (!std::isdigit(static_cast<unsigned char>(c))) {
-        throw std::runtime_error(
-          std::string("invalid value for ") + env_var_name +
-          ": expected a non-negative integer, got '" + env_var_value + "'");
-      }
+    // Parse the integer value; use pos to detect trailing characters.
+    std::size_t pos = 0;
+    int value;
+    try {
+      value = std::stoi(env_var_value, &pos);
+    } catch (const std::invalid_argument &) {
+      throw std::runtime_error(
+        std::string("invalid value for ") + env_var_name +
+        ": '" + env_var_value + "' is not a valid integer");
+    } catch (const std::out_of_range &) {
+      throw std::runtime_error(
+        std::string("invalid value for ") + env_var_name +
+        ": value is out of range");
     }
 
-    // Parse the integer value
-    int value = std::stoi(env_var_value);
+    if (pos != env_var_value.size()) {
+      throw std::runtime_error(
+        std::string("invalid value for ") + env_var_name +
+        ": trailing characters after integer: '" + env_var_value.substr(pos) + "'");
+    }
+
+    if (value < 0) {
+      throw std::runtime_error(
+        std::string("invalid value for ") + env_var_name +
+        ": value must be non-negative, got " + std::to_string(value));
+    }
 
     if (get_should_use_old_flushing_behavior()) {
       throw std::runtime_error(
@@ -132,16 +147,6 @@ get_flush_period_seconds()
     }
 
     return value;
-  } catch (const std::invalid_argument &) {
-    throw std::runtime_error(
-            std::string("failed to get env var '") + env_var_name +
-            "': value is not a valid integer"
-    );
-  } catch (const std::out_of_range &) {
-    throw std::runtime_error(
-            std::string("failed to get env var '") + env_var_name +
-            "': value is out of range"
-    );
   } catch (const std::runtime_error & error) {
     throw std::runtime_error(
             std::string("failed to get env var '") + env_var_name + "': " + error.what()

--- a/rcl_logging_spdlog/test/test_logging_interface.cpp
+++ b/rcl_logging_spdlog/test/test_logging_interface.cpp
@@ -342,6 +342,86 @@ TEST_F(LoggingTest, init_invalid_flush_setting)
   rcutils_reset_error();
 }
 
+TEST_F(LoggingTest, init_with_custom_flush_period)
+{
+  RestoreEnvVar env_var("RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS");
+  rcpputils::set_env_var("RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS", "10");
+
+  ASSERT_EQ(RCL_LOGGING_RET_OK, rcl_logging_external_initialize(nullptr, nullptr, allocator));
+
+  rcl_logging_external_log(RCUTILS_LOG_SEVERITY_INFO, nullptr, "Test message with custom flush");
+
+  EXPECT_EQ(RCL_LOGGING_RET_OK, rcl_logging_external_shutdown());
+
+  std::string log_file_path = find_single_log(nullptr).string();
+  std::ifstream log_file(log_file_path);
+  std::stringstream actual_log;
+  actual_log << log_file.rdbuf();
+  EXPECT_THAT(actual_log.str(), ::testing::HasSubstr("Test message with custom flush"));
+}
+
+TEST_F(LoggingTest, init_with_immediate_flush)
+{
+  RestoreEnvVar env_var("RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS");
+  rcpputils::set_env_var("RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS", "0");
+
+  ASSERT_EQ(RCL_LOGGING_RET_OK, rcl_logging_external_initialize(nullptr, nullptr, allocator));
+
+  // Log a message - with immediate flush, it should be written right away
+  rcl_logging_external_log(RCUTILS_LOG_SEVERITY_INFO, nullptr, "Immediate flush test");
+
+  // Read the log file before shutdown to verify immediate flushing
+  std::string log_file_path = find_single_log(nullptr).string();
+  std::ifstream log_file(log_file_path);
+  std::stringstream actual_log;
+  actual_log << log_file.rdbuf();
+  EXPECT_THAT(actual_log.str(), ::testing::HasSubstr("Immediate flush test"));
+
+  EXPECT_EQ(RCL_LOGGING_RET_OK, rcl_logging_external_shutdown());
+}
+
+TEST_F(LoggingTest, init_with_invalid_flush_period_non_integer)
+{
+  RestoreEnvVar env_var("RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS");
+  rcpputils::set_env_var("RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS", "abc");
+
+  ASSERT_EQ(RCL_LOGGING_RET_ERROR, rcl_logging_external_initialize(nullptr, nullptr, allocator));
+  std::string error_state_str = rcutils_get_error_string().str;
+  using ::testing::HasSubstr;
+  ASSERT_THAT(
+    error_state_str,
+    HasSubstr("not a valid integer"));
+  rcutils_reset_error();
+}
+
+TEST_F(LoggingTest, init_with_invalid_flush_period_negative)
+{
+  RestoreEnvVar env_var("RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS");
+  rcpputils::set_env_var("RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS", "-1");
+
+  ASSERT_EQ(RCL_LOGGING_RET_ERROR, rcl_logging_external_initialize(nullptr, nullptr, allocator));
+  std::string error_state_str = rcutils_get_error_string().str;
+  using ::testing::HasSubstr;
+  ASSERT_THAT(
+    error_state_str,
+    HasSubstr("negative"));
+  rcutils_reset_error();
+}
+
+TEST_F(LoggingTest, init_with_invalid_flush_period_trailing_chars)
+{
+  RestoreEnvVar env_var("RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS");
+  rcpputils::set_env_var("RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS", "5abc");
+
+  ASSERT_EQ(RCL_LOGGING_RET_ERROR, rcl_logging_external_initialize(nullptr, nullptr, allocator));
+  std::string error_state_str = rcutils_get_error_string().str;
+  using ::testing::HasSubstr;
+  ASSERT_THAT(
+    error_state_str,
+    HasSubstr("trailing characters"));
+  rcutils_reset_error();
+}
+
 TEST_F(LoggingTest, full_cycle)
 {
   ASSERT_EQ(RCL_LOGGING_RET_OK, rcl_logging_external_initialize(nullptr, nullptr, allocator));


### PR DESCRIPTION
## Description

Adds the option to configure the logging interval to file using an environment variable `RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS`. Previously this was hardcoded to 5s, which is the default to maintain backwards compatibility. This allows the user to change the interval to a different value, notably including 0, which means unbuffered writes. An example where this is useful is on [discourse](https://discourse.openrobotics.org/t/better-console-logging/44012/21?u=achllle)
Added documentation for the experimental behavior env flag that was not documented yet.

## Testing steps

Save the below `Dockerfile`

```
FROM ros:rolling

# Install dependencies
RUN apt-get update && apt-get install -y \
    ros-rolling-demo-nodes-cpp \
    multitail \
    git \
    python3-colcon-common-extensions \
    python3-rosdep \
    && rm -rf /var/lib/apt/lists/*

# Create workspace
WORKDIR /ros2_ws

# Clone the fork with configurable flush period
RUN git clone --branch configurable_flush_period \
    https://github.com/Achllle/rcl_logging.git src/rcl_logging

RUN apt-get update && rosdep install --from-paths src --ignore-src -r -y

# Build rcl_logging overlay
RUN . /opt/ros/rolling/setup.sh && \
    colcon build --packages-up-to rcl_logging_spdlog

# Create launch file
RUN mkdir -p /ros2_ws/launch
COPY <<EOF /ros2_ws/launch/demo.launch.py
from launch import LaunchDescription
from launch_ros.actions import Node

def generate_launch_description():
    return LaunchDescription([
        Node(
            package='demo_nodes_cpp',
            executable='talker',
            name='my_talker_node',
            output='screen',
            emulate_tty=True,
        ),
        Node(
            package='demo_nodes_cpp',
            executable='listener',
            name='my_listener_node',
            output='screen',
            emulate_tty=True,
        )
    ])
EOF

# Create entrypoint script
COPY <<EOF /ros2_ws/entrypoint.sh
#!/bin/bash
set -e

# Source the overlay
source /ros2_ws/install/setup.bash

# Set log directory
export ROS_LOG_DIR=\${ROS_LOG_DIR:-/tmp/ros_logs}
mkdir -p "\$ROS_LOG_DIR"

# Print configuration
echo "=== RCL Logging Demo ==="
echo "RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS=\${RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS:-not set (default 5s)}"
echo "ROS_LOG_DIR=\$ROS_LOG_DIR"
echo "========================"
echo ""

# Launch nodes in background, redirect output to /dev/null
ros2 launch /ros2_ws/launch/demo.launch.py > /dev/null 2>&1 &
LAUNCH_PID=\$!

# Wait for log files to appear
sleep 2

# Use multitail to follow all log files in ROS_LOG_DIR
exec multitail -Q 1 "\$ROS_LOG_DIR/*.log"
EOF

RUN chmod +x /ros2_ws/entrypoint.sh

# Default environment
ENV ROS_LOG_DIR=/tmp/ros_logs

ENTRYPOINT ["/ros2_ws/entrypoint.sh"]
```

then `docker build -t rcl-logging-demo .`

* default behavior: `docker run -it --rm rcl-logging-demo:latest`: logs are buffered for 5s
* try other interval: `docker run -it --rm -e RCL_LOGGING_SPDLOG_FLUSH_PERIOD_SECONDS=0 rcl-logging-demo:latest`: logs are unbuffered

### Did you use Generative AI?

yes, Claude Opus 4.5

### Additional Information

relevant issue about config file: #92 
